### PR TITLE
add c counter

### DIFF
--- a/src/main/kotlin/cc/polyfrost/evergreenhud/EvergreenHUD.kt
+++ b/src/main/kotlin/cc/polyfrost/evergreenhud/EvergreenHUD.kt
@@ -14,6 +14,7 @@ class EvergreenHUD {
         Armour()
         Biome()
         BlockAbove()
+        CCounter()
         Combo()
         Coordinates()
         CPS()

--- a/src/main/kotlin/cc/polyfrost/evergreenhud/hud/CCounter.kt
+++ b/src/main/kotlin/cc/polyfrost/evergreenhud/hud/CCounter.kt
@@ -1,0 +1,33 @@
+package cc.polyfrost.evergreenhud.hud
+
+import cc.polyfrost.oneconfig.config.Config
+import cc.polyfrost.oneconfig.config.annotations.HUD
+import cc.polyfrost.oneconfig.config.annotations.Switch
+import cc.polyfrost.oneconfig.config.data.Mod
+import cc.polyfrost.oneconfig.config.data.ModType
+import cc.polyfrost.oneconfig.hud.SingleTextHud
+import cc.polyfrost.oneconfig.utils.dsl.mc
+
+class CCounter: Config(Mod("C Counter", ModType.HUD, "/assets/evergreenhud/evergreenhud.svg"), "evergreenhud/ccounter.json", false) {
+    @HUD(name = "Main")
+    var hud = CCounterHud()
+
+    init {
+        initialize()
+    }
+
+    class CCounterHud: SingleTextHud("C", true, 400, 70) {
+
+        @Switch(
+                name = "Simplified"
+        )
+        var simplified = false
+
+        override fun getText(example: Boolean): String {
+            if (mc.thePlayer == null) return "Unknown"
+            return if (simplified) mc.renderGlobal.debugInfoRenders.split("/")[0].replace("C: ", "")
+                else mc.renderGlobal.debugInfoRenders.split(" ")[1]
+        }
+    }
+
+}

--- a/src/main/kotlin/cc/polyfrost/evergreenhud/hud/CCounter.kt
+++ b/src/main/kotlin/cc/polyfrost/evergreenhud/hud/CCounter.kt
@@ -21,7 +21,7 @@ class CCounter: Config(Mod("C Counter", ModType.HUD, "/assets/evergreenhud/everg
         @Switch(
                 name = "Simplified"
         )
-        var simplified = false
+        var simplified = true
 
         override fun getText(example: Boolean): String {
             if (mc.thePlayer == null) return "Unknown"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds a C Counter. Has an option called simplified which removes the /1000 or /10000. Not really sure what it means but it does change so that's why it's an option. Simplified is on by default. There is almost certainly a better way to do this but I don't really understand all this fancy text stuff ngl I'm amazed I got this to work

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
I remember someone requested it a long time ago idk where

## How to test
<!-- Provide steps to test this PR -->
Join a world and turn on C Counter. Test simplified option and without.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Add C Counter
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A