### PR TITLE
Biome Mod Optimizations

### DIFF
--- a/src/main/kotlin/cc/polyfrost/evergreenhud/hud/Biome.kt
+++ b/src/main/kotlin/cc/polyfrost/evergreenhud/hud/Biome.kt
@@ -6,7 +6,6 @@ import cc.polyfrost.oneconfig.config.data.Mod
 import cc.polyfrost.oneconfig.config.data.ModType
 import cc.polyfrost.oneconfig.hud.SingleTextHud
 import cc.polyfrost.oneconfig.utils.dsl.mc
-import net.minecraft.util.BlockPos
 
 class Biome: Config(Mod("Biome", ModType.HUD, "/assets/evergreenhud/evergreenhud.svg"), "evergreenhud/biome.json", false) {
     @HUD(name = "Main")
@@ -19,11 +18,8 @@ class Biome: Config(Mod("Biome", ModType.HUD, "/assets/evergreenhud/evergreenhud
     class BiomeHud: SingleTextHud("Biome", true, 400, 50) {
         override fun getText(example: Boolean): String {
             val player = mc.thePlayer ?: return "Unknown"
-
-            val playerPos = BlockPos(player.posX, player.posY, player.posZ)
-            val playerChunk = mc.theWorld.getChunkFromBlockCoords(playerPos)
-
-            return playerChunk.getBiome(playerPos, mc.theWorld.worldChunkManager).biomeName
+            
+            return mc.theWorld.getBiomeGenFromCoords(player.getPosition()).biomeName
         }
 
     }


### PR DESCRIPTION
## Description
Instead of getting the position from the player's chunk, this, gets the biome from the player's exact position. And the code is shorter.

## Related Issue
Maybe in 1 chunk, there's more than 1 biome, so it gets the biome from the exact player position.
How is it possible for there to be more than one biome in a chunk? It can be checked if the player is on the border between two biomes and a chunk joins them, in any case, this fix makes the mod more accurate
Fixes 1