### PR TITLE
Feature: Held Item Lore

### DIFF
--- a/src/main/java/org/polyfrost/evergreenhud/mixins/GuiIngameAccessor.java
+++ b/src/main/java/org/polyfrost/evergreenhud/mixins/GuiIngameAccessor.java
@@ -1,0 +1,43 @@
+package org.polyfrost.evergreenhud.mixins;
+
+import net.minecraft.client.gui.GuiIngame;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(GuiIngame.class)
+public interface GuiIngameAccessor {
+
+    @Accessor("recordPlaying")
+    String getRecordPlaying();
+
+    @Accessor("recordIsPlaying")
+    boolean getRecordIsPlaying();
+
+    @Accessor("recordPlayingUpFor")
+    int getRecordPlayingUpFor();
+
+    @Accessor("titlesTimer")
+    int getTitlesTimer();
+
+    @Accessor("titleFadeIn")
+    int getTitleFadeIn();
+
+    @Accessor("titleFadeOut")
+    int getTitleFadeOut();
+
+    @Accessor("titleDisplayTime")
+    int getTitleDisplayTime();
+
+    @Accessor("displayedTitle")
+    String getDisplayedTitle();
+
+    @Accessor("displayedSubTitle")
+    String getDisplayedSubTitle();
+
+    @Accessor()
+    int getRemainingHighlightTicks();
+
+    @Accessor()
+    ItemStack getHighlightingItemStack();
+}

--- a/src/main/java/org/polyfrost/evergreenhud/mixins/GuiIngameAccessor.java
+++ b/src/main/java/org/polyfrost/evergreenhud/mixins/GuiIngameAccessor.java
@@ -1,49 +1,11 @@
 package org.polyfrost.evergreenhud.mixins;
 
 import net.minecraft.client.gui.GuiIngame;
-// import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(GuiIngame.class)
 public interface GuiIngameAccessor {
-
-// most of the below interface is from VanillaHUD.
-// it's been commented out in case anyone else finds it useful
-// until then, it's only being used for the HeldItemLore.kt class
-// -ery
-/*
-    @Accessor("recordPlaying")
-    String getRecordPlaying();
-
-    @Accessor("recordIsPlaying")
-    boolean getRecordIsPlaying();
-
-    @Accessor("recordPlayingUpFor")
-    int getRecordPlayingUpFor();
-
-    @Accessor("titlesTimer")
-    int getTitlesTimer();
-
-    @Accessor("titleFadeIn")
-    int getTitleFadeIn();
-
-    @Accessor("titleFadeOut")
-    int getTitleFadeOut();
-
-    @Accessor("titleDisplayTime")
-    int getTitleDisplayTime();
-
-    @Accessor("displayedTitle")
-    String getDisplayedTitle();
-
-    @Accessor("displayedSubTitle")
-    String getDisplayedSubTitle();
-
-    @Accessor()
-    ItemStack getHighlightingItemStack();
-*/
-
     @Accessor()
     int getRemainingHighlightTicks();
 }

--- a/src/main/java/org/polyfrost/evergreenhud/mixins/GuiIngameAccessor.java
+++ b/src/main/java/org/polyfrost/evergreenhud/mixins/GuiIngameAccessor.java
@@ -1,13 +1,18 @@
 package org.polyfrost.evergreenhud.mixins;
 
 import net.minecraft.client.gui.GuiIngame;
-import net.minecraft.item.ItemStack;
+// import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(GuiIngame.class)
 public interface GuiIngameAccessor {
 
+// most of the below interface is from VanillaHUD.
+// it's been commented out in case anyone else finds it useful
+// until then, it's only being used for the HeldItemLore.kt class
+// -ery
+/*
     @Accessor("recordPlaying")
     String getRecordPlaying();
 
@@ -36,8 +41,9 @@ public interface GuiIngameAccessor {
     String getDisplayedSubTitle();
 
     @Accessor()
-    int getRemainingHighlightTicks();
+    ItemStack getHighlightingItemStack();
+*/
 
     @Accessor()
-    ItemStack getHighlightingItemStack();
+    int getRemainingHighlightTicks();
 }

--- a/src/main/kotlin/org/polyfrost/evergreenhud/EvergreenHUD.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/EvergreenHUD.kt
@@ -30,6 +30,7 @@ class EvergreenHUD {
         GameMode()
         GameType()
         HeightLimit()
+        HeldItemLore()
         InGameTime()
         Inventory()
         Map()

--- a/src/main/kotlin/org/polyfrost/evergreenhud/hud/HeldItemLore.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/hud/HeldItemLore.kt
@@ -17,21 +17,6 @@ import org.polyfrost.evergreenhud.mixins.GuiIngameAccessor
 import org.polyfrost.evergreenhud.utils.ItemStackUtils.getLore
 import kotlin.math.min
 
-/**
-    HeldItemLore.kt
-
-    A Kotlin class written by Erymanthus | RayDeeUx, Wyvest, and ImToggle
-    for the EvergreenHUD mod.
-
-    Displays the item lore of the currently held item (if there is any).
-
-    Allows for options to limit the number of lines to show, as well as skipping any
-    empty lore lines.
-
-    Also allows for omitting the item of the name from the HUD
-    (useful if VanillaHUD) is also installed.
- */
-
 class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/helditemlore.json", false) {
     @HUD(name = "Main")
     var hud = HeldItemLoreHud()
@@ -40,13 +25,10 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
         initialize()
     }
 
-    class HeldItemLoreHud : TextHud(false, 50, 50) {
+    class HeldItemLoreHud : TextHud(true, 50, 50) {
 
         @Switch(name = "Fade Out", description = "If disabled, the held item lore HUD will persist indefinitely.")
-        var fadeOut: Boolean = true
-
-        @Switch(name = "Instant Fade", description = "Requires \"Fade Out\" to be enabled, otherwise this toggle is ignored.")
-        var instantFade: Boolean = false
+        var fadeOut: Boolean = false
 
         @Switch(name = "Remove Empty Lines")
         var removeEmptyLines: Boolean = false
@@ -63,7 +45,7 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
 
         @Exclude private var opacity = 0
 
-        @Exclude private final val TOOLTIP: MutableList<String> = mutableListOf(
+        @Exclude private val TOOLTIP: MutableList<String> = mutableListOf(
             "§bExample Item Lore §7(Left click and hold to drag this!)",
             "",
             "§7If you can read this, you're spending",
@@ -143,7 +125,7 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
                 if (fadeOut) (remainingTicks * 256 / 10)
                 else 255
             if (o > 255) o = 255
-            opacity = if (instantFade) 255 else o
+            opacity = o
             return o > 0 && super.shouldShow()
         }
 

--- a/src/main/kotlin/org/polyfrost/evergreenhud/hud/HeldItemLore.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/hud/HeldItemLore.kt
@@ -17,7 +17,7 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
         initialize()
     }
 
-    class HeldItemLoreHud : TextHud(false, 0, 0) {
+    class HeldItemLoreHud : TextHud(false, 50, 50) {
 
         @Switch(
             name = "Fade Out"

--- a/src/main/kotlin/org/polyfrost/evergreenhud/hud/HeldItemLore.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/hud/HeldItemLore.kt
@@ -1,0 +1,66 @@
+package org.polyfrost.evergreenhud.hud
+
+import cc.polyfrost.oneconfig.config.Config
+import cc.polyfrost.oneconfig.config.annotations.HUD
+import cc.polyfrost.oneconfig.config.annotations.Switch
+import cc.polyfrost.oneconfig.config.data.Mod
+import cc.polyfrost.oneconfig.config.data.ModType
+import cc.polyfrost.oneconfig.utils.dsl.mc
+import cc.polyfrost.oneconfig.hud.TextHud
+import org.polyfrost.evergreenhud.utils.ItemStackUtils.getLore
+
+class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/helditemlore.json", false) {
+    @HUD(name = "Main")
+    var hud = HeldItemLoreHud()
+
+    init {
+        initialize()
+    }
+
+    class HeldItemLoreHud : TextHud(false, 0, 0) {
+
+        @Switch(
+            name = "Fade Out"
+        )
+        var fadeOut = true
+
+        @Switch(
+            name = "Instant Fade"
+        )
+        var instantFade = false
+
+        @Switch(
+            name = "Remove Empty Lines"
+        )
+        var removeEmptyLines = false
+
+        override fun getLines(lines: MutableList<String>, example: Boolean) {
+            if (mc.thePlayer == null) {
+                lines.add("Unknown")
+                return
+            }
+
+            val theHeldItem =
+                //#if MC>=11202
+                //$$ mc.player.heldItemMainhand
+                //#else
+                mc.thePlayer.heldItem
+            //#endif
+            val itemName = theHeldItem.displayName
+            val itemLore = theHeldItem.getLore()
+            if (itemName.isNotEmpty()) lines.add(itemName)
+            if (itemLore.isNotEmpty()) {
+                if (!removeEmptyLines) lines.addAll(itemLore)
+                else {
+                    for (line in itemLore) {
+                        if (line.isNotEmpty()) {
+                            lines.add(line)
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+
+}

--- a/src/main/kotlin/org/polyfrost/evergreenhud/hud/HeldItemLore.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/hud/HeldItemLore.kt
@@ -3,15 +3,21 @@ package org.polyfrost.evergreenhud.hud
 import cc.polyfrost.oneconfig.config.Config
 import cc.polyfrost.oneconfig.config.annotations.Exclude
 import cc.polyfrost.oneconfig.config.annotations.HUD
-import cc.polyfrost.oneconfig.config.annotations.Number
 import cc.polyfrost.oneconfig.config.annotations.Switch
+import cc.polyfrost.oneconfig.config.core.OneColor
 import cc.polyfrost.oneconfig.config.data.Mod
 import cc.polyfrost.oneconfig.config.data.ModType
 import cc.polyfrost.oneconfig.hud.TextHud
+import cc.polyfrost.oneconfig.libs.universal.UGraphics
 import cc.polyfrost.oneconfig.libs.universal.UMinecraft
+import cc.polyfrost.oneconfig.renderer.NanoVGHelper
+import cc.polyfrost.oneconfig.renderer.TextRenderer
+import cc.polyfrost.oneconfig.utils.color.ColorUtils
 import cc.polyfrost.oneconfig.utils.dsl.mc
 import org.polyfrost.evergreenhud.mixins.GuiIngameAccessor
 import org.polyfrost.evergreenhud.utils.ItemStackUtils.getLore
+import kotlin.math.min
+
 
 class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/helditemlore.json", false) {
     @HUD(name = "Main")
@@ -23,11 +29,17 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
 
     class HeldItemLoreHud : TextHud(false, 50, 50) {
 
-        @Switch(name = "Fade Out (Instantly)", description = "If disabled, the Held Item Lore HUD will remain on the screen indefinitely.")
+        @Switch(name = "Fade Out", description = "If disabled, the held item lore HUD will persist indefinitely.")
         var fadeOut: Boolean = true
+
+        @Switch(name = "Instant Fade", description = "Requires \"Fade Out\" to be enabled, otherwise this toggle is ignored.")
+        var instantFade: Boolean = false
 
         @Switch(name = "Remove Empty Lines")
         var removeEmptyLines: Boolean = false
+
+        @Switch(name = "Skip Item Name")
+        var skipItemName: Boolean = false
 
         // @Number(name = "Extra Seconds of Held Item Lore", min = 0F, max = 60F, description = "The number of extra seconds the tooltip will remain on screen before fading out.")
         // var extraSeconds = 0
@@ -35,18 +47,75 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
 
         @Exclude private var opacity = 0 // a place to start in case anyone gets around to implementing gradual fadeout -ery
 
-        @Exclude private val TOOLTIP = mutableListOf(
+        @Exclude private final val TOOLTIP: MutableList<String> = mutableListOf(
             "§bExample Item Lore §7(Left click and hold to drag this!)",
             "",
             "§7If you can read this, you're spending",
             "§cWAY §7too much time in §2Minecraft§7.",
             "",
-            "§7You need to get out of your house",
+            "§7You need to §bget out of your house",
             "§7and earn some §7§osocial points.",
             "",
             "§c§lGet out there §r§7and live your life.",
             "§7Make friends. Go on a hike. §7§nDo both at once!",
         )
+
+        fun drawLine(line: String?, x: Float, y: Float, c: OneColor, scale: Float) {
+            val color = OneColor(
+                ColorUtils.setAlpha(
+                    c.rgb,
+                    min(c.alpha.toDouble(), opacity.toDouble()).toInt()
+                ) or (this.opacity shl 24)
+            )
+            UGraphics.enableBlend()
+            TextRenderer.drawScaledString(line, x, y, color.rgb, TextRenderer.TextType.toType(textType), scale)
+            UGraphics.disableBlend()
+        }
+
+        override fun drawBackground(x: Float, y: Float, width: Float, height: Float, scale: Float) {
+            val nanoVGHelper = NanoVGHelper.INSTANCE
+            nanoVGHelper.setupAndDraw(true) { vg: Long ->
+                val bgColor =
+                    ColorUtils.setAlpha(
+                        bgColor.rgb,
+                        min(bgColor.alpha.toDouble(), opacity.toDouble())
+                            .toInt()
+                    )
+                val borderColor =
+                    ColorUtils.setAlpha(
+                        borderColor.rgb,
+                        min(
+                            borderColor.alpha.toDouble(),
+                            opacity.toDouble()
+                        ).toInt()
+                    )
+                if (rounded) {
+                    nanoVGHelper.drawRoundedRect(vg, x, y, width, height, bgColor, cornerRadius * scale)
+                    if (border) nanoVGHelper.drawHollowRoundRect(
+                        vg,
+                        x - borderSize * scale,
+                        y - borderSize * scale,
+                        width + borderSize * scale,
+                        height + borderSize * scale,
+                        borderColor,
+                        cornerRadius * scale,
+                        borderSize * scale
+                    )
+                } else {
+                    nanoVGHelper.drawRect(vg, x, y, width, height, bgColor)
+                    if (border) nanoVGHelper.drawHollowRoundRect(
+                        vg,
+                        x - borderSize * scale,
+                        y - borderSize * scale,
+                        width + borderSize * scale,
+                        height + borderSize * scale,
+                        borderColor,
+                        0f,
+                        borderSize * scale
+                    )
+                }
+            }
+        }
 
         override fun shouldShow(): Boolean {
             val inGameGUI: GuiIngameAccessor = UMinecraft.getMinecraft().ingameGUI as GuiIngameAccessor
@@ -58,6 +127,7 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
                 if (fadeOut) (remainingTicks * 256 / 10)
                 else 255
             if (o > 255) o = 255
+            opacity = if (instantFade) 255 else o
             return o > 0 && super.shouldShow()
         }
 
@@ -75,14 +145,7 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
 
             if (example) {
                 lines.clear()
-                if (!removeEmptyLines) lines.addAll(TOOLTIP)
-                else {
-                    for (line in TOOLTIP) {
-                        if (line.isNotEmpty()) {
-                            lines.add(line)
-                        }
-                    }
-                }
+                addXToY(TOOLTIP, lines)
                 return
             }
 
@@ -96,19 +159,22 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
             //#endif
             val itemName = theHeldItem.displayName
             val itemLore = theHeldItem.getLore()
-            if (itemName.isNotEmpty()) lines.add(itemName)
+            if (itemName.isNotEmpty() && !skipItemName) lines.add("§r$itemName")
             if (itemLore.isNotEmpty()) {
-                if (!removeEmptyLines) lines.addAll(itemLore)
-                else {
-                    for (line in itemLore) {
-                        if (line.isNotEmpty()) {
-                            lines.add(line)
-                        }
+                addXToY(itemLore, lines)
+            }
+        }
+
+        private fun addXToY(theListToAdd: List<String>, lines: MutableList<String>) {
+            if (!removeEmptyLines) lines.addAll(theListToAdd)
+            else {
+                for (line in theListToAdd) {
+                    if (line.isNotEmpty()) {
+                        lines.add(line)
                     }
                 }
             }
         }
-
     }
 
 }

--- a/src/main/kotlin/org/polyfrost/evergreenhud/hud/HeldItemLore.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/hud/HeldItemLore.kt
@@ -60,11 +60,11 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
             "§7Make friends. Go on a hike. §7§nDo both at once!",
         )
 
-        fun drawLine(line: String?, x: Float, y: Float, c: OneColor, scale: Float) {
+        override fun drawLine(line: String?, x: Float, y: Float, scale: Float) {
             val color = OneColor(
                 ColorUtils.setAlpha(
-                    c.rgb,
-                    min(c.alpha.toDouble(), opacity.toDouble()).toInt()
+                    this.color.rgb,
+                    min(this.color.alpha.toDouble(), opacity.toDouble()).toInt()
                 ) or (this.opacity shl 24)
             )
             UGraphics.enableBlend()
@@ -159,7 +159,7 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
             //#endif
             val itemName = theHeldItem.displayName
             val itemLore = theHeldItem.getLore()
-            if (itemName.isNotEmpty() && !skipItemName) lines.add("§r$itemName")
+            if (itemName.isNotEmpty() && !skipItemName) lines.add("§r$itemName§r") // §r to avoid coloring either the inventory or enderchest huds
             if (itemLore.isNotEmpty()) {
                 addXToY(itemLore, lines)
             }

--- a/src/main/kotlin/org/polyfrost/evergreenhud/hud/HeldItemLore.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/hud/HeldItemLore.kt
@@ -1,9 +1,8 @@
 package org.polyfrost.evergreenhud.hud
 
 import cc.polyfrost.oneconfig.config.Config
-import cc.polyfrost.oneconfig.config.annotations.Exclude
-import cc.polyfrost.oneconfig.config.annotations.HUD
-import cc.polyfrost.oneconfig.config.annotations.Switch
+import cc.polyfrost.oneconfig.config.annotations.*
+import cc.polyfrost.oneconfig.config.annotations.Number
 import cc.polyfrost.oneconfig.config.core.OneColor
 import cc.polyfrost.oneconfig.config.data.Mod
 import cc.polyfrost.oneconfig.config.data.ModType
@@ -18,6 +17,20 @@ import org.polyfrost.evergreenhud.mixins.GuiIngameAccessor
 import org.polyfrost.evergreenhud.utils.ItemStackUtils.getLore
 import kotlin.math.min
 
+/**
+    HeldItemLore.kt
+
+    A Kotlin class written by Erymanthus | RayDeeUx, Wyvest, and ImToggle
+    for the EvergreenHUD mod.
+
+    Displays the item lore of the currently held item (if there is any).
+
+    Allows for options to limit the number of lines to show, as well as skipping any
+    empty lore lines.
+
+    Also allows for omitting the item of the name from the HUD
+    (useful if VanillaHUD) is also installed.
+ */
 
 class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/helditemlore.json", false) {
     @HUD(name = "Main")
@@ -41,11 +54,14 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
         @Switch(name = "Skip Item Name")
         var skipItemName: Boolean = false
 
+        @Number(name = "Stop After Line", min = 0F, max = 100F, description = "The HUD will stop rendering lore lines after this amount. Leave at 0 to render all lines in an item lore.\nThis setting won't count the item's display name as a line.")
+         var stopAfterLine: Int = 0
+
         // @Number(name = "Extra Seconds of Held Item Lore", min = 0F, max = 60F, description = "The number of extra seconds the tooltip will remain on screen before fading out.")
         // var extraSeconds = 0
         // above line is my attempt at extending the time a tooltip had before fading out -ery
 
-        @Exclude private var opacity = 0 // a place to start in case anyone gets around to implementing gradual fadeout -ery
+        @Exclude private var opacity = 0
 
         @Exclude private final val TOOLTIP: MutableList<String> = mutableListOf(
             "§bExample Item Lore §7(Left click and hold to drag this!)",
@@ -145,7 +161,7 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
 
             if (example) {
                 lines.clear()
-                addXToY(TOOLTIP, lines)
+                addTextToHUD(TOOLTIP, lines)
                 return
             }
 
@@ -161,18 +177,17 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
             val itemLore = theHeldItem.getLore()
             if (itemName.isNotEmpty() && !skipItemName) lines.add("§r$itemName§r") // §r to avoid coloring either the inventory or enderchest huds
             if (itemLore.isNotEmpty()) {
-                addXToY(itemLore, lines)
+                addTextToHUD(itemLore, lines)
             }
         }
 
-        private fun addXToY(theListToAdd: List<String>, lines: MutableList<String>) {
-            if (!removeEmptyLines) lines.addAll(theListToAdd)
-            else {
-                for (line in theListToAdd) {
-                    if (line.isNotEmpty()) {
-                        lines.add(line)
-                    }
-                }
+        private fun addTextToHUD(theListToAdd: List<String>, lines: MutableList<String>) {
+            var index = 0
+            for (line in theListToAdd) {
+                if (line.isEmpty() && removeEmptyLines) continue
+                lines.add(line)
+                index++
+                if (index >= stopAfterLine && stopAfterLine > 0) break
             }
         }
     }

--- a/src/main/kotlin/org/polyfrost/evergreenhud/hud/HeldItemLore.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/hud/HeldItemLore.kt
@@ -57,8 +57,8 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
         @Number(name = "Stop After Line", min = 0F, max = 100F, description = "The HUD will stop rendering lore lines after this amount. Leave at 0 to render all lines in an item lore.\nThis setting won't count the item's display name as a line.")
          var stopAfterLine: Int = 0
 
-        // @Number(name = "Extra Seconds of Held Item Lore", min = 0F, max = 60F, description = "The number of extra seconds the tooltip will remain on screen before fading out.")
-        // var extraSeconds = 0
+         // @Number(name = "Extra Seconds", min = 0F, max = 60F, description = "The number of extra seconds the tooltip will remain on screen before fading out.")
+         // var extraSeconds: Int = 0
         // above line is my attempt at extending the time a tooltip had before fading out -ery
 
         @Exclude private var opacity = 0
@@ -187,7 +187,7 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
                 if (line.isEmpty() && removeEmptyLines) continue
                 lines.add(line)
                 index++
-                if (index >= stopAfterLine && stopAfterLine > 0) break
+                if (stopAfterLine in 1..index) break
             }
         }
     }

--- a/src/main/kotlin/org/polyfrost/evergreenhud/hud/HeldItemLore.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/hud/HeldItemLore.kt
@@ -1,12 +1,16 @@
 package org.polyfrost.evergreenhud.hud
 
 import cc.polyfrost.oneconfig.config.Config
+import cc.polyfrost.oneconfig.config.annotations.Exclude
 import cc.polyfrost.oneconfig.config.annotations.HUD
+import cc.polyfrost.oneconfig.config.annotations.Number
 import cc.polyfrost.oneconfig.config.annotations.Switch
 import cc.polyfrost.oneconfig.config.data.Mod
 import cc.polyfrost.oneconfig.config.data.ModType
-import cc.polyfrost.oneconfig.utils.dsl.mc
 import cc.polyfrost.oneconfig.hud.TextHud
+import cc.polyfrost.oneconfig.libs.universal.UMinecraft
+import cc.polyfrost.oneconfig.utils.dsl.mc
+import org.polyfrost.evergreenhud.mixins.GuiIngameAccessor
 import org.polyfrost.evergreenhud.utils.ItemStackUtils.getLore
 
 class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/helditemlore.json", false) {
@@ -19,26 +23,70 @@ class HeldItemLore : Config(Mod("Held Item Lore", ModType.HUD), "evergreenhud/he
 
     class HeldItemLoreHud : TextHud(false, 50, 50) {
 
-        @Switch(
-            name = "Fade Out"
-        )
-        var fadeOut = true
+        @Switch(name = "Fade Out (Instantly)", description = "If disabled, the Held Item Lore HUD will remain on the screen indefinitely.")
+        var fadeOut: Boolean = true
 
-        @Switch(
-            name = "Instant Fade"
-        )
-        var instantFade = false
+        @Switch(name = "Remove Empty Lines")
+        var removeEmptyLines: Boolean = false
 
-        @Switch(
-            name = "Remove Empty Lines"
+        // @Number(name = "Extra Seconds of Held Item Lore", min = 0F, max = 60F, description = "The number of extra seconds the tooltip will remain on screen before fading out.")
+        // var extraSeconds = 0
+        // above line is my attempt at extending the time a tooltip had before fading out -ery
+
+        @Exclude private var opacity = 0 // a place to start in case anyone gets around to implementing gradual fadeout -ery
+
+        @Exclude private val TOOLTIP = mutableListOf(
+            "§bExample Item Lore §7(Left click and hold to drag this!)",
+            "",
+            "§7If you can read this, you're spending",
+            "§cWAY §7too much time in §2Minecraft§7.",
+            "",
+            "§7You need to get out of your house",
+            "§7and earn some §7§osocial points.",
+            "",
+            "§c§lGet out there §r§7and live your life.",
+            "§7Make friends. Go on a hike. §7§nDo both at once!",
         )
-        var removeEmptyLines = false
+
+        override fun shouldShow(): Boolean {
+            val inGameGUI: GuiIngameAccessor = UMinecraft.getMinecraft().ingameGUI as GuiIngameAccessor
+
+            // val ticksPerSecond = 20
+            // val extraTicks = (extraSeconds * ticksPerSecond)
+            val remainingTicks = inGameGUI.getRemainingHighlightTicks() // + extraTicks
+            var o: Int =
+                if (fadeOut) (remainingTicks * 256 / 10)
+                else 255
+            if (o > 255) o = 255
+            return o > 0 && super.shouldShow()
+        }
 
         override fun getLines(lines: MutableList<String>, example: Boolean) {
-            if (mc.thePlayer == null) {
+            if (
+            //#if MC>=11202
+            //$$ mc.player
+            //#else
+            mc.thePlayer
+        //#endif
+                == null) {
                 lines.add("Unknown")
                 return
             }
+
+            if (example) {
+                lines.clear()
+                if (!removeEmptyLines) lines.addAll(TOOLTIP)
+                else {
+                    for (line in TOOLTIP) {
+                        if (line.isNotEmpty()) {
+                            lines.add(line)
+                        }
+                    }
+                }
+                return
+            }
+
+            if (!shouldShow()) return
 
             val theHeldItem =
                 //#if MC>=11202

--- a/src/main/kotlin/org/polyfrost/evergreenhud/utils/ItemStackUtils.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/utils/ItemStackUtils.kt
@@ -1,0 +1,15 @@
+package org.polyfrost.evergreenhud.utils
+
+import net.minecraft.item.ItemStack
+
+object ItemStackUtils {
+    fun ItemStack.getLore(): List<String> {
+        var list: MutableList<String> = ArrayList<String>()
+        val theTagCompound = this.tagCompound ?: return list
+        val theTagList = theTagCompound.getCompoundTag("display").getTagList("Lore", 8)
+        for (i in 0..(theTagList.tagCount() - 1)) {
+            list.add(theTagList.getStringTagAt(i))
+        }
+        return list
+    }
+}

--- a/src/main/resources/mixins.evergreenhud.json
+++ b/src/main/resources/mixins.evergreenhud.json
@@ -10,6 +10,7 @@
   "client": [
     "EntityPlayerMixin",
     "ForgeHooksMixin",
+    "GuiIngameAccessor",,
     "LevelheadAboveHeadRenderMixin",
     "MainMixin",
     "RendererLivingEntityMixin"

--- a/src/main/resources/mixins.evergreenhud.json
+++ b/src/main/resources/mixins.evergreenhud.json
@@ -10,7 +10,7 @@
   "client": [
     "EntityPlayerMixin",
     "ForgeHooksMixin",
-    "GuiIngameAccessor",,
+    "GuiIngameAccessor",
     "LevelheadAboveHeadRenderMixin",
     "MainMixin",
     "RendererLivingEntityMixin"


### PR DESCRIPTION
## Description
Adds a new HUD displaying the name and lore of an item (if any).
Also has options to have HUD persist indefinitely and remove empty lines.

## How to test
Search for `Held Item Lore` in OneConfig and enable. Adjust position via `Edit HUD` and adjust other options as necessary.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Add new Held Item Lore HUD, including options to show Item Lore indefinitely and remove empty lines in the item lore.
```
<!--
## Documentation
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->