### PR TITLE
dont show 1

### DIFF
--- a/src/main/kotlin/org/polyfrost/evergreenhud/hud/Armour.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/hud/Armour.kt
@@ -15,8 +15,17 @@ import net.minecraft.client.renderer.GlStateManager
 import net.minecraft.client.renderer.RenderHelper
 import net.minecraft.init.Items
 import net.minecraft.item.Item
+import net.minecraft.item.ItemAxe
 import net.minecraft.item.ItemBow
+import net.minecraft.item.ItemFishingRod
+import net.minecraft.item.ItemFlintAndSteel
+import net.minecraft.item.ItemHoe
+import net.minecraft.item.ItemPickaxe
+import net.minecraft.item.ItemShears
+import net.minecraft.item.ItemSpade
 import net.minecraft.item.ItemStack
+import net.minecraft.item.ItemSword
+import net.minecraft.item.ItemTool
 import org.polyfrost.evergreenhud.config.HudConfig
 import kotlin.math.ceil
 
@@ -255,7 +264,16 @@ class Armour : HudConfig("ArmourHud", "evergreenhud/armour.json", false) {
 
                 val amount = getItemAmount(if (stack.item is ItemBow) Items.arrow else stack.item).let {
 
-                    if (it != 0 && it != 1) it.toString()
+                    if (it != 0 && it != 1 &&
+                        !(stack.item is ItemHoe) &&
+                        !(stack.item is ItemPickaxe) &&
+                        !(stack.item is ItemShears) &&
+                        !(stack.item is ItemSword) &&
+                        !(stack.item is ItemAxe) &&
+                        !(stack.item is ItemFishingRod) &&
+                        !(stack.item is ItemFlintAndSteel) &&
+                        !(stack.item is ItemSpade))
+                        it.toString()
                     else null
                 }
                 

--- a/src/main/kotlin/org/polyfrost/evergreenhud/hud/Armour.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/hud/Armour.kt
@@ -254,7 +254,9 @@ class Armour : HudConfig("ArmourHud", "evergreenhud/armour.json", false) {
                 if (!type && i > 0) translation += offset + texts[i - 1].second + if (texts[i - 1].second > 0) iconPadding else 0
 
                 val amount = getItemAmount(if (stack.item is ItemBow) Items.arrow else stack.item).let {
-                    if (it != 0) it.toString() else null
+
+                    if (it != 0 && it != 1) it.toString()
+                    else null
                 }
                 
                 RenderHelper.enableGUIStandardItemLighting()

--- a/src/main/kotlin/org/polyfrost/evergreenhud/hud/Armour.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/hud/Armour.kt
@@ -262,7 +262,7 @@ class Armour : HudConfig("ArmourHud", "evergreenhud/armour.json", false) {
 
                 if (!type && i > 0) translation += offset + texts[i - 1].second + if (texts[i - 1].second > 0) iconPadding else 0
 
-                val amount = getItemAmount(if (stack.item is ItemBow) Items.arrow else stack.item).let {
+                val amount = getItemAmount(if (stack.item is ItemBow) ItemStack(Items.arrow) else stack).let {
 
                     if (it != 0 && it != 1 &&
                         !(stack.item is ItemHoe) &&


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
made it not show items when item stack is 1, such as a sword

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->