### PR TITLE
Enabled & some fixes for Ping-Mod

### DIFF
--- a/src/main/kotlin/org/polyfrost/evergreenhud/config/ModConfig.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/config/ModConfig.kt
@@ -34,7 +34,7 @@ object ModConfig : Config(Mod(EvergreenHUD.NAME, ModType.HUD, "/assets/evergreen
     @SubConfig var map = Map()
     @SubConfig var mapType = MapType()
     @SubConfig var memory = Memory()
-//    @SubConfig var ping = Ping()
+    @SubConfig var ping = Ping()
     @SubConfig var pitch = Pitch()
     @SubConfig var placeCount = PlaceCount()
     @SubConfig var playerPreview = PlayerPreview()

--- a/src/main/kotlin/org/polyfrost/evergreenhud/hud/Ping.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/hud/Ping.kt
@@ -7,7 +7,7 @@ import cc.polyfrost.oneconfig.libs.universal.UMatrixStack
 import cc.polyfrost.oneconfig.utils.dsl.mc
 import org.polyfrost.evergreenhud.config.HudConfig
 
-class Ping: HudConfig("Ping", "evergreenhud/ping.json", false) {
+class Ping: HudConfig("Ping", "evergreenhud/ping.json", true) {
     @HUD(name = "Main")
     var hud = PingHud()
 

--- a/src/main/kotlin/org/polyfrost/evergreenhud/utils/ServerPinger.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/utils/ServerPinger.kt
@@ -50,7 +50,7 @@ object ServerPinger {
 
                 if (ticks % interval() == 0) {
                     Multithreading.runAsync {
-                        serverGetter()?.let(this::ping)
+                        serverGetter()?.let(this::ping) ?: run { ping = null }
                     }
                 }
             }
@@ -62,7 +62,7 @@ object ServerPinger {
                 ticks = 0 // just so that ticks doesn't count up infinitely
 
                 Multithreading.runAsync {
-                    serverGetter()?.let(this::ping)
+                    serverGetter()?.let(this::ping) ?: run { ping = null }
                 }
             }
         }

--- a/src/main/kotlin/org/polyfrost/evergreenhud/utils/ServerPinger.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/utils/ServerPinger.kt
@@ -2,6 +2,7 @@ package org.polyfrost.evergreenhud.utils
 
 import cc.polyfrost.oneconfig.config.annotations.Exclude
 import cc.polyfrost.oneconfig.events.EventManager
+import cc.polyfrost.oneconfig.events.event.ReceivePacketEvent
 import cc.polyfrost.oneconfig.events.event.Stage
 import cc.polyfrost.oneconfig.events.event.TickEvent
 import cc.polyfrost.oneconfig.libs.eventbus.Subscribe
@@ -12,6 +13,7 @@ import net.minecraft.client.multiplayer.ServerData
 import net.minecraft.network.EnumConnectionState
 import net.minecraft.network.NetworkManager
 import net.minecraft.network.handshake.client.C00Handshake
+import net.minecraft.network.play.server.S01PacketJoinGame
 import net.minecraft.network.status.INetHandlerStatusClient
 import net.minecraft.network.status.client.C00PacketServerQuery
 import net.minecraft.network.status.client.C01PacketPing
@@ -39,9 +41,6 @@ object ServerPinger {
         private var ticks = 0
         init {
             EventManager.INSTANCE.register(this)
-            Multithreading.runAsync {
-                serverGetter()?.let(this::ping)
-            }
         }
 
         @Subscribe
@@ -53,6 +52,17 @@ object ServerPinger {
                     Multithreading.runAsync {
                         serverGetter()?.let(this::ping)
                     }
+                }
+            }
+        }
+
+        @Subscribe
+        fun onPacketReceive(event: ReceivePacketEvent) {
+            if (event.packet is S01PacketJoinGame) {
+                ticks = 0 // just so that ticks doesn't count up infinitely
+
+                Multithreading.runAsync {
+                    serverGetter()?.let(this::ping)
                 }
             }
         }


### PR DESCRIPTION
## Description
- Enabled Ping-Mod
  - *I have no idea, why it was disabled in the first place?*
- Fixed ping-update being delayed when joining new server:
  - *When joining a server, the ping update is delayed until the tick interval is reached. However, the tick counter doesn't reset when the player joins a server/world, which means the next ping could be delayed by up to the full interval (e20 to 120 seconds). To fix this, the ping should update shortly after connecting. The ping update iniside the init function is not needed.*
- Fixed showing old server ping when joining singleplayer:
  - *When first joining a server, `ServerPinger` correctly fetches and displays the ping for that server. However, if the player later joins a singleplayer world, `serverGetter` returns null, so no new ping is fetched. Since the previous ping value is never cleared, it incorrectly remains visible in singleplayer worlds, showing the old server's ping.*

## Related Issue(s)
*NONE*

## How to test
1. Build the modified version.
2. Open OneConfig and enable the **Ping** mod.

## Release Notes
```release-note
- Enabled Ping-Mod
- Fixed ping-update being delayed when joining new server
- Fixed showing old server ping when joining singleplayer
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->