### PR TITLE
feat: use OneConfig framebuffer event for frame timing

### DIFF
--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/utils/FrameTimeHelper.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/utils/FrameTimeHelper.kt
@@ -1,14 +1,9 @@
 package org.polyfrost.evergreenhud.client.utils
 
-//? if >= 26
-import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderEvents as WorldRenderEvents
-//? if >= 1.21.10 && < 26
-//import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents
-//? if < 1.21.10
-//import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents
 import org.polyfrost.oneconfig.api.event.v1.EventManager
 import org.polyfrost.oneconfig.api.event.v1.eventHandler
 import org.polyfrost.oneconfig.api.event.v1.events.Event
+import org.polyfrost.oneconfig.api.event.v1.events.FramebufferRenderEvent
 import org.polyfrost.oneconfig.api.event.v1.events.TickEvent
 
 object FrameTimeHelper {
@@ -25,10 +20,7 @@ object FrameTimeHelper {
         private set
 
     fun initialize() {
-        //? if >= 1.21.10
-        WorldRenderEvents.END_MAIN.register {
-        //? if < 1.21.10
-        //WorldRenderEvents.END.register {
+        eventHandler { _: FramebufferRenderEvent.End ->
             val now = System.nanoTime()
             val frameTime = now - lastTime
             lastTime = now


### PR DESCRIPTION
## Description
Replaces Fabric’s world render event with [OneConfig’s framebuffer event](https://github.com/Polyfrost/OneConfig/blob/40a987a36fe4478665f8599e90cfbee1530e6c7b/minecraft/src/main/java/org/polyfrost/oneconfig/internal/mixin/events/Mixin_FramebufferRenderEvent.java) for frame-time tracking.

This measures the complete frame including presentation and VSync, which should make it more accurate. Also makes Ornithe port easier because that fabric event doesn't exist in Ornithe.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
!basic Improved FPS measurements
```