### PR TITLE
Fix: sync global text color to Keystrokes HUD (claude.ai)

### DIFF
--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/keystrokes/KeystrokesHud.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/keystrokes/KeystrokesHud.kt
@@ -153,6 +153,7 @@ class KeystrokesHud : Hud(
                 addCallback(option) { keys.rev.value++ }
             }
             addCallback("unpressedBg") { pushToDesigner() }
+            addCallback("unpressedText") { pushToDesigner() }
             pushToDesigner()
             handlers.add(eventHandler { (btn, state): MouseInputEvent ->
                 if (state == 1) onClick { it.matchesMouseButton(btn) }
@@ -174,6 +175,9 @@ class KeystrokesHud : Hud(
         bgColor = unpressedBg.rawArgb
         bgChroma = unpressedBg.chroma
         bgChromaSpeed = unpressedBg.chromaSpeed
+        textColor = unpressedText.rawArgb
+        textChroma = unpressedText.chroma
+        textChromaSpeed = unpressedText.chromaSpeed
     }
 
     private fun pullFromDesigner(): Boolean {
@@ -181,6 +185,10 @@ class KeystrokesHud : Hud(
         if (bgColor != unpressedBg.rawArgb || bgChroma != unpressedBg.chroma || bgChromaSpeed != unpressedBg.chromaSpeed) {
             unpressedBg = PolyColor(bgColor, bgChroma, bgChromaSpeed)
             pulled = true
+        }
+            if (textColor != unpressedText.rawArgb || textChroma != unpressedText.chroma || textChromaSpeed != unpressedText.chromaSpeed) {
+        unpressedText = PolyColor(textColor, textChroma, textChromaSpeed)
+        pulled = true
         }
         if (pulled) keys.rev.value++
         return pulled


### PR DESCRIPTION
i hope its good.

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->