### PR TITLE
Add stackable sorting + add ambient and bad effect sorting

### DIFF
--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/potion/PotionEffectsHud.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/potion/PotionEffectsHud.kt
@@ -151,7 +151,7 @@ class PotionEffectsHud : Hud(
             SORT_BAD_EFFECTS
         ]
     )
-    var sorting = arrayOf(SORT_BAD_EFFECTS, SORT_DURATION)
+    var sorting = emptyArray<String>()
 
     @Switch(title = "Reversed")
     var reversed = false
@@ -193,12 +193,7 @@ class PotionEffectsHud : Hud(
         return ordered.map { row(it) }
     }
 
-    private fun sortEffects(
-        effects: List<MobEffectInstance>,
-        sortingStack: Array<String>,
-        reversed: Boolean
-    ): List<MobEffectInstance> {
-
+    private fun sortEffects(effects: List<MobEffectInstance>, sortingStack: Array<String>, reversed: Boolean): List<MobEffectInstance> {
         var sorted = effects
 
         // Sorting is reversed because the last rule in the list is the highest priority.
@@ -209,10 +204,7 @@ class PotionEffectsHud : Hud(
         return if (reversed) sorted.asReversed() else sorted
     }
 
-    private fun sortByRule(
-        effects: List<MobEffectInstance>,
-        rule: String
-    ): List<MobEffectInstance> {
+    private fun sortByRule(effects: List<MobEffectInstance>, rule: String): List<MobEffectInstance> {
         return when (rule) {
             SORT_NAME -> effects.sortedBy { it.effect.value().displayName.string }
             SORT_DURATION -> effects.sortedBy { if (it.isInfiniteDuration) Int.MAX_VALUE else it.duration }

--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/potion/PotionEffectsHud.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/potion/PotionEffectsHud.kt
@@ -23,7 +23,7 @@ import org.polyfrost.compose.composables.size
 import org.polyfrost.compose.layout.PolyAlign
 import org.polyfrost.compose.render.ImageLoader
 import org.polyfrost.compose.render.PolyColor
-import org.polyfrost.oneconfig.api.config.v1.annotations.Dropdown
+import org.polyfrost.oneconfig.api.config.v1.annotations.DraggableList
 import org.polyfrost.oneconfig.api.config.v1.annotations.RadioButton
 import org.polyfrost.oneconfig.api.config.v1.annotations.Slider
 import org.polyfrost.oneconfig.api.config.v1.annotations.Switch
@@ -42,10 +42,11 @@ private const val FONT_SIZE = 8f
 
 private const val ROMAN = 0
 
-private const val VANILLA = 0
-private const val NAME = 1
-private const val DURATION = 2
-private const val AMPLIFIER = 3
+private const val SORT_NAME = "Name"
+private const val SORT_DURATION = "Duration"
+private const val SORT_AMPLIFIER = "Amplifier"
+private const val SORT_AMBIENT = "Ambient Effects"
+private const val SORT_BAD_EFFECTS = "Bad Effects"
 
 private const val INFINITE = "**:**"
 
@@ -138,8 +139,19 @@ class PotionEffectsHud : Hud(
     @Switch(title = "Ambient Effects", description = "Show effects coming from beacons and conduits.")
     var showAmbient = true
 
-    @Dropdown(title = "Sorting", options = ["Vanilla", "Name", "Duration", "Amplifier"])
-    var sorting = VANILLA
+    @DraggableList(
+        title = "Sorting",
+        description = "Which sorting rules to apply, by priority.",
+        checkable = true,
+        options = [
+            SORT_NAME,
+            SORT_DURATION,
+            SORT_AMPLIFIER,
+            SORT_AMBIENT,
+            SORT_BAD_EFFECTS
+        ]
+    )
+    var sorting = arrayOf(SORT_BAD_EFFECTS, SORT_DURATION)
 
     @Switch(title = "Reversed")
     var reversed = false
@@ -177,14 +189,38 @@ class PotionEffectsHud : Hud(
             else emptyList()
         }
 
-        val sorted = when (sorting) {
-            NAME -> effects.sortedBy { it.effect.value().displayName.string }
-            DURATION -> effects.sortedBy { if (it.isInfiniteDuration) Int.MAX_VALUE else it.duration }
-            AMPLIFIER -> effects.sortedByDescending { it.amplifier }
+        val ordered = sortEffects(effects, sorting, reversed)
+        return ordered.map { row(it) }
+    }
+
+    private fun sortEffects(
+        effects: List<MobEffectInstance>,
+        sortingStack: Array<String>,
+        reversed: Boolean
+    ): List<MobEffectInstance> {
+
+        var sorted = effects
+
+        // Sorting is reversed because the last rule in the list is the highest priority.
+        for (rule in sortingStack.reversed()) {
+            sorted = sortByRule(sorted, rule)
+        }
+
+        return if (reversed) sorted.asReversed() else sorted
+    }
+
+    private fun sortByRule(
+        effects: List<MobEffectInstance>,
+        rule: String
+    ): List<MobEffectInstance> {
+        return when (rule) {
+            SORT_NAME -> effects.sortedBy { it.effect.value().displayName.string }
+            SORT_DURATION -> effects.sortedBy { if (it.isInfiniteDuration) Int.MAX_VALUE else it.duration }
+            SORT_AMPLIFIER -> effects.sortedByDescending { it.amplifier }
+            SORT_AMBIENT -> effects.sortedBy { it.isAmbient }
+            SORT_BAD_EFFECTS -> effects.sortedBy { it.effect.value().isBeneficial }
             else -> effects
         }
-        val ordered = if (reversed) sorted.asReversed() else sorted
-        return ordered.map { row(it) }
     }
 
     private fun currentEffects(): List<MobEffectInstance> {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

With DraggableList being available, I've added the ability to allow sorting to be stackable. I also took this opportunity to bring back Ambient and Bad Effects sorting, which restores some parity from https://github.com/Tellinq/Potion-Effects

Note: I am not a fan of the defaults not being vanilla, but an empty array just makes the DraggableList assume everything should be selected, which I would argue is worse. This default at least presents to end users that this exists and can be customized.

I also would suggest perhaps changing the default preview to have a third effect to account for harmful effects, this will better represent the current sorting.

https://github.com/user-attachments/assets/f513dcb0-e9fa-4436-a50c-110de7a6e35a


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None unless someone lists this exact scenario while this PR exists.

## How to test
<!-- Provide steps to test this PR -->
The main gist is to just toggle effects sorting on and off and observe the sorting changes. Ensure that each toggle by priority is as expected

Make sure to have a beacon/conduit nearby to also test.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Effect sorting can now be stacked
Added the ability to sort by ambient effects
Added the ability to sort by harmful effects
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No. https://docs.polyfrost.org/oneconfig (this template looks copy-pasted from an older template prior to the domain migration, as docs.polyfrost.cc just redirects to the aforementioned link) doesn't contain any documentation to EvergreenHUD.