### PR TITLE
fix: update selected-item mixin targets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -184,6 +184,5 @@ publishMods {
         minecraftVersions.addAll(compatibleVersions)
 
         requires("oneconfig")
-        requires("fabric-api")
     }
 }

--- a/src/main/java/org/polyfrost/evergreenhud/mixins/client/Mixin_InventoryPlayer_SelectedItemChangedEvent.java
+++ b/src/main/java/org/polyfrost/evergreenhud/mixins/client/Mixin_InventoryPlayer_SelectedItemChangedEvent.java
@@ -15,7 +15,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class Mixin_InventoryPlayer_SelectedItemChangedEvent {
     @Inject(
             method = {
-                    "swapPaint", "setSelectedSlot", "setSelectedHotbarSlot",
+                    //? if >= 1.21.5 {
+                    "setSelectedSlot",
+                    //?} elif >= 1.21.4 {
+                    /*"setSelectedHotbarSlot",
+                    *///?} else
+                    //"swapPaint",
                     "pickSlot", "replaceWith"
             },
             at = @At(
@@ -23,8 +28,7 @@ public abstract class Mixin_InventoryPlayer_SelectedItemChangedEvent {
                     opcode = Opcodes.PUTFIELD,
                     target = "Lnet/minecraft/world/entity/player/Inventory;selected:I",
                     shift = At.Shift.AFTER
-            ),
-            require = 0
+            )
     )
     private void selectedItemChangeCallback(CallbackInfo ci) {
         LocalPlayer player = Minecraft.getInstance().player;

--- a/src/main/java/org/polyfrost/evergreenhud/mixins/client/Mixin_NetHandlerPlayClient_SelectedItemChangedEvent.java
+++ b/src/main/java/org/polyfrost/evergreenhud/mixins/client/Mixin_NetHandlerPlayClient_SelectedItemChangedEvent.java
@@ -14,7 +14,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ClientPacketListener.class)
 public class Mixin_NetHandlerPlayClient_SelectedItemChangedEvent {
     @Inject(
-            method = { "handleSetHeldSlot", "handleSetCarriedItem" },
+            //~ if < 1.21.2 'handleSetHeldSlot' -> 'handleSetCarriedItem'
+            method = "handleSetHeldSlot",
             at = @At(
                     //? if <= 1.21.4 {
                     /*value = "FIELD",
@@ -25,8 +26,7 @@ public class Mixin_NetHandlerPlayClient_SelectedItemChangedEvent {
                     target = "Lnet/minecraft/world/entity/player/Inventory;setSelectedSlot(I)V",
                     //?}
                     shift = At.Shift.AFTER
-            ),
-            require = 0
+            )
     )
     private void selectedItemChangeCallback(CallbackInfo ci) {
         LocalPlayer player = Minecraft.getInstance().player;

--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/EvergreenHudClient.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/EvergreenHudClient.kt
@@ -59,6 +59,7 @@ object EvergreenHudClient : ClientModInitializer {
 
         registerIfSupported(Battery.isSupported(), ::BatteryHud)
 
+        BlockChangeEvent()
         BlockPositionChangedEvent()
         ServerDamageEntityEvent()
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,6 @@
     "depends": {
         "minecraft": "${minecraft}",
         "fabricloader": ">=0.15.11",
-        "oneconfigv1": ">=1.1.3",
-        "fabric-api": "*"
+        "oneconfigv1": ">=1.1.3"
     }
 }


### PR DESCRIPTION
## Description
fix: update selected-item mixin targets: (8cf5b179419235632d3438de8bebfb00b2cdd79d)
- Used stonecutter to guard version specific mixin targets to mixins
- It has `require = 0` but minecraft dev plugin was not happy

fix: register BlockChangeEvent (bdcd5ef91416af7e7105151ed5b62a5cf7635806)
- For some reason this was never registered before, making the blocks above hud sometimes inaccurate

chore: remove direct fabric-api dependency (d3a4a481f69b754c80b08a74ea4ef1e1797f8328)
- After https://github.com/Polyfrost/EvergreenHUD/commit/6c265516d0c987e9f893a011d8b4fc4e38f6f579 the direct dependency is no longer needed
- `oneconfigv1` already in `fabric.mod.json` provides the other `fabric-api` module dependencies already

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Fixed inaccurate blocks above HUD updates
```