### PR TITLE
Add per-effect/effect type overrides/sorting + filtering

### DIFF
--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/potion/EffectCatalog.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/potion/EffectCatalog.kt
@@ -1,0 +1,23 @@
+package org.polyfrost.evergreenhud.client.hud.potion
+
+import net.minecraft.core.registries.BuiltInRegistries
+
+object EffectCatalog {
+    data class Entry(val path: String, val title: String)
+
+    private var cached: List<Entry>? = null
+
+    val ENTRIES: List<Entry>
+        get() = cached ?: buildEntries().also { cached = it }
+
+    private fun buildEntries(): List<Entry> {
+        val entries = mutableListOf<Entry>()
+        for (effect in BuiltInRegistries.MOB_EFFECT) {
+            val id = BuiltInRegistries.MOB_EFFECT.getKey(effect) ?: continue
+            entries += Entry(id.path, effect.displayName.string)
+        }
+        return entries
+    }
+
+    val titleToPath: Map<String, String> get() = ENTRIES.associate { it.title to it.path }
+}

--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/potion/EffectComponentSettings.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/potion/EffectComponentSettings.kt
@@ -1,0 +1,77 @@
+package org.polyfrost.evergreenhud.client.hud.potion
+
+import org.polyfrost.compose.render.PolyColor
+import org.polyfrost.evergreenhud.client.utils.copy
+import org.polyfrost.oneconfig.api.config.v1.annotations.Color
+import org.polyfrost.oneconfig.api.config.v1.annotations.MultiSelectDropdown
+import org.polyfrost.oneconfig.api.config.v1.annotations.RadioButton
+import org.polyfrost.oneconfig.api.config.v1.annotations.RangeSlider
+import org.polyfrost.oneconfig.api.config.v1.annotations.Slider
+import org.polyfrost.oneconfig.api.config.v1.annotations.Switch
+
+class EffectComponentSettings : EffectComponentValues {
+    @Switch(title = "Show Icon", subcategory = "Icon")
+    override var iconEnabled = true
+    @Switch(title = "Blink Icon", subcategory = "Icon")
+    override var iconBlink = true
+
+    @Switch(title = "Show Name", subcategory = "Name")
+    override var nameEnabled = true
+    @Switch(title = "Blink Name", subcategory = "Name")
+    override var nameBlink = true
+    @Color(title = "Name Color", subcategory = "Name")
+    override var nameColor = PolyColor.rgba(255, 255, 255, 255)
+    @Switch(title = "Amplifier", subcategory = "Name")
+    override var showAmplifier = true
+    @RadioButton(title = "Amplifier Style", options = ["Roman", "Arabic"], subcategory = "Name")
+    override var amplifierStyle = ROMAN
+
+    @Switch(title = "Show Duration", subcategory = "Duration")
+    override var durationEnabled = true
+    @Switch(title = "Blink Duration", subcategory = "Duration")
+    override var durationBlink = true
+    @Color(title = "Duration Color", subcategory = "Duration")
+    override var durationColor = PolyColor.rgba(255, 255, 255, 255)
+
+    @Switch(title = "Show Effect(s)", subcategory = "Filtering")
+    override var showEffects = true
+
+    @MultiSelectDropdown(title = "Ambient Effects", subcategory = "Filtering", options = ["Show all ambient", "Show all nonambient"])
+    override var ambientFilter = booleanArrayOf(true, true)
+
+    @MultiSelectDropdown(title = "Effect Categories", subcategory = "Filtering", options = ["Show all beneficial", "Show all neutral", "Show all harmful"])
+    override var categoryFilter = booleanArrayOf(true, true, true)
+
+    @MultiSelectDropdown(title = "Permanent Effects", subcategory = "Filtering", options = ["Show all permanent", "Show all finite"])
+    override var permanentEffects = booleanArrayOf(true, true)
+
+    @RangeSlider(title = "Duration Range", subcategory = "Filtering", min = 0F, max = 500F, step = 1F)
+    override var durationRange = floatArrayOf(0f, 0f)
+
+    @RangeSlider(title = "Amplifier Range", subcategory = "Filtering", min = 0F, max = 10F, step = 1F)
+    override var amplifierRange = floatArrayOf(0f, 0f)
+
+    @Slider(title = "Blink Threshold (s)", subcategory = "Blinking", min = 0F, max = 60F, step = 1F)
+    override var blinkThreshold = 10f
+
+    fun copyFrom(other: EffectComponentSettings) {
+        iconEnabled = other.iconEnabled
+        iconBlink = other.iconBlink
+        nameEnabled = other.nameEnabled
+        nameBlink = other.nameBlink
+        nameColor = other.nameColor.copy()
+        showAmplifier = other.showAmplifier
+        amplifierStyle = other.amplifierStyle
+        durationEnabled = other.durationEnabled
+        durationBlink = other.durationBlink
+        durationColor = other.durationColor.copy()
+
+        showEffects = other.showEffects
+        ambientFilter = other.ambientFilter.copyOf()
+        categoryFilter = other.categoryFilter.copyOf()
+        permanentEffects = other.permanentEffects.copyOf()
+        durationRange = other.durationRange.copyOf()
+        amplifierRange = other.amplifierRange.copyOf()
+        blinkThreshold = other.blinkThreshold
+    }
+}

--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/potion/EffectComponentValues.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/potion/EffectComponentValues.kt
@@ -1,0 +1,24 @@
+package org.polyfrost.evergreenhud.client.hud.potion
+
+import org.polyfrost.compose.render.PolyColor
+
+interface EffectComponentValues {
+    val iconEnabled: Boolean
+    val iconBlink: Boolean
+    val nameEnabled: Boolean
+    val nameBlink: Boolean
+    val nameColor: PolyColor
+    val showAmplifier: Boolean
+    val amplifierStyle: Int
+    val durationEnabled: Boolean
+    val durationBlink: Boolean
+    val durationColor: PolyColor
+
+    val showEffects: Boolean
+    val ambientFilter: BooleanArray
+    val categoryFilter: BooleanArray
+    val permanentEffects: BooleanArray
+    val durationRange: FloatArray
+    val amplifierRange: FloatArray
+    val blinkThreshold: Float
+}

--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/potion/PotionEffectsHud.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/potion/PotionEffectsHud.kt
@@ -2,11 +2,13 @@ package org.polyfrost.evergreenhud.client.hud.potion
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import net.minecraft.core.registries.BuiltInRegistries
 //? if < 1.21.11
 //import net.minecraft.resources.ResourceLocation
 //? if >= 1.21.11
 import net.minecraft.resources.Identifier as ResourceLocation
+import net.minecraft.world.effect.MobEffectCategory
 import net.minecraft.world.effect.MobEffectInstance
 import org.jetbrains.skia.Image
 import org.jetbrains.skia.Paint
@@ -20,20 +22,29 @@ import org.polyfrost.compose.composables.PolyText
 import org.polyfrost.compose.composables.align
 import org.polyfrost.compose.composables.padding
 import org.polyfrost.compose.composables.size
+import org.polyfrost.compose.composables.width
 import org.polyfrost.compose.layout.PolyAlign
+import org.polyfrost.compose.mc.McFontQueue.measureWidth
 import org.polyfrost.compose.render.ImageLoader
 import org.polyfrost.compose.render.PolyColor
 import org.polyfrost.evergreenhud.client.hooks.VanillaHudCompat
+import org.polyfrost.oneconfig.api.config.v1.Node
+import org.polyfrost.oneconfig.api.config.v1.Tree
 import org.polyfrost.oneconfig.api.config.v1.annotations.DraggableList
-import org.polyfrost.oneconfig.api.config.v1.annotations.RadioButton
 import org.polyfrost.oneconfig.api.config.v1.annotations.Slider
 import org.polyfrost.oneconfig.api.config.v1.annotations.Switch
+import org.polyfrost.oneconfig.api.config.v1.annotations.Option
+import org.polyfrost.oneconfig.api.config.v1.annotations.RadioButton
+import org.polyfrost.oneconfig.api.config.v1.collect.impl.OneConfigCollector
 import org.polyfrost.oneconfig.api.event.v1.eventHandler
 import org.polyfrost.oneconfig.api.event.v1.events.TickEvent
 import org.polyfrost.oneconfig.api.hud.v1.Font
 import org.polyfrost.oneconfig.api.hud.v1.Hud
+import org.polyfrost.oneconfig.api.hud.v1.HudAnchor
 import org.polyfrost.oneconfig.api.hud.v1.HudManager
+import org.polyfrost.oneconfig.api.hud.v1.Section
 import org.polyfrost.oneconfig.utils.v1.dsl.mc
+import org.polyfrost.oneconfig.utils.v1.MHUtils.setAccessible
 import org.slf4j.LoggerFactory
 import kotlin.math.PI
 import kotlin.math.cos
@@ -43,18 +54,31 @@ private const val ICON_GAP = 3f
 private const val LINE_GAP = 1f
 private const val FONT_SIZE = 8f
 
-private const val ROMAN = 0
+const val ROMAN = 0
 
-private const val SORT_NAME = "Name"
-private const val SORT_DURATION = "Duration"
-private const val SORT_AMPLIFIER = "Amplifier"
-private const val SORT_AMBIENT = "Ambient Effects"
-private const val SORT_BAD_EFFECTS = "Bad Effects"
+private const val NAME = "Name"
+private const val DURATION = "Duration"
+private const val AMPLIFIER = "Amplifier"
+private const val AMBIENT_EFFECTS = "Ambient Effects"
+private const val BENEFICIAL_EFFECTS = "Beneficial Effects"
+private const val NEUTRAL_EFFECTS = "Neutral Effects"
+private const val HARMFUL_EFFECTS = "Harmful Effects"
 
 private const val INFINITE = "**:**"
 
 private const val BLINK_PERIOD = 1000L
 private const val BLINK_MIN_FADE = 0.25f
+
+private const val EDITOR_DIM_ALPHA = 0.5f
+
+private const val MODE_AUTO = 0
+private const val MODE_FULL = 1
+private const val MODE_SINGLE_LINE = 2
+private const val MODE_STACKED = 3
+
+private const val DIRECTION_AUTO = 0
+private const val DIRECTION_VERTICAL = 1
+private const val DIRECTION_HORIZONTAL = 2
 
 class PotionEffectsHud : Hud(
     id = "potion_effects.json",
@@ -68,10 +92,23 @@ class PotionEffectsHud : Hud(
         private val ROMAN_NUMERALS =
             arrayOf("M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I")
 
+        private fun charWidth(scale: Float): Float =
+            measureWidth?.invoke(" ", scale) ?: (FONT_SIZE * scale * 0.5f)
+
         private val EXAMPLES = listOf(
             Example("speed", "Speed", 1200, 1),
             Example("strength", "Strength", 140, 0),
         )
+
+        val ALL_LEAF_FIELDS: List<String> by lazy {
+            EffectComponentSettings::class.java.declaredFields
+                .filter { field ->
+                    field.declaredAnnotations.any { ann ->
+                        (ann as java.lang.annotation.Annotation).annotationType().isAnnotationPresent(Option::class.java)
+                    }
+                }
+                .map { it.name }
+        }
 
         private val iconPaint = Paint()
         private val iconCache = HashMap<ResourceLocation, Image?>()
@@ -122,60 +159,66 @@ class PotionEffectsHud : Hud(
 
     private class Example(val id: String, val name: String, val ticks: Int, val amplifier: Int)
 
-    private data class Row(val icon: Image?, val name: String?, val duration: String?, val fade: Float)
+    private data class Row(
+        val icon: Image?,
+        val name: String?,
+        val duration: String?,
+        val fade: Float,
+        val iconBlink: Boolean,
+        val nameBlink: Boolean,
+        val nameColor: PolyColor,
+        val durationBlink: Boolean,
+        val durationColor: PolyColor,
+        val dimmed: Boolean,
+    )
 
-    @Switch(title = "Icon")
-    var showIcon = true
+    private class RowStyle(
+        val iconAlpha: Float,
+        val nameFade: Float,
+        val durationFade: Float,
+        val nameColor: PolyColor,
+        val durationColor: PolyColor,
+    )
 
-    @Switch(title = "Name")
-    var showName = true
-
-    @Switch(title = "Duration")
-    var showDuration = true
-
-    @Switch(title = "Amplifier", description = "Show the effect level next to its name.")
-    var showAmplifier = true
-
-    @RadioButton(title = "Amplifier Style", options = ["Roman", "Arabic"])
-    var amplifierStyle = ROMAN
-
-    @Switch(title = "Ambient Effects", description = "Show effects coming from beacons and conduits.")
-    var showAmbient = true
+    private var categoryScopes = PerCategoryEffectSettings()
+    private var effectScopes = PerEffectSettings()
 
     @DraggableList(
         title = "Sorting",
         description = "Which sorting rules to apply, by priority.",
+        subcategory = "Sorting",
         checkable = true,
-        options = [
-            SORT_NAME,
-            SORT_DURATION,
-            SORT_AMPLIFIER,
-            SORT_AMBIENT,
-            SORT_BAD_EFFECTS
-        ]
     )
     var sorting = emptyArray<String>()
 
-    @Switch(title = "Reversed")
+    @DraggableList(
+        title = "Overrides",
+        description = "Override one or more effects' appearance.",
+        subcategory = "Overrides",
+        checkable = true
+    )
+    var overrides = emptyArray<String>()
+
+    @Switch(title = "Reversed", subcategory = "Sorting")
     var reversed = false
 
-    @Slider(title = "Spacing", min = 0F, max = 10F, step = 1F)
+    @Slider(title = "Spacing", min = 0F, max = 10F, step = 1F, subcategory = "Dimensions")
     var spacing = 2f
+
+    @RadioButton(title = "Text Alignment", options = ["Auto", "Left", "Center", "Right"], subcategory = "Dimensions")
+    var textAlignment = 0
+
+    @RadioButton(title = "Layout Mode", options = ["Auto", "Full", "Single Line", "Stacked"], subcategory = "Dimensions")
+    var layoutMode = MODE_AUTO
+
+    @RadioButton(title = "List Direction", options = ["Auto", "Vertical", "Horizontal"], subcategory = "Dimensions")
+    var listDirection = DIRECTION_AUTO
 
     @Switch(
         title = "Hide Vanilla Status Effects",
         description = "Turns off VanillaHUD's own status effects element, so it does not draw on top of this one.",
     )
     var hideVanillaEffects = false
-
-    @Slider(
-        title = "Blink Threshold (s)",
-        description = "Fade an effect in and out once its remaining duration drops below this. 0 disables it.",
-        min = 0F,
-        max = 30F,
-        step = 1F,
-    )
-    var blinkThreshold = 5f
 
     private var rows = mutableStateOf<List<Row>>(emptyList())
 
@@ -188,6 +231,23 @@ class PotionEffectsHud : Hud(
             if (VanillaHudCompat.isPresent) {
                 eventHandler { _: TickEvent ->
                     VanillaHudCompat.hideStatusEffects(hideVanillaEffects && !hidden)
+                }
+            }
+
+            for (scope in categoryScopes.scopeDefs) {
+                if (!scope.isOverride) continue
+                val check = { scope.title !in overrides }
+                for (field in ALL_LEAF_FIELDS) {
+                    if (field in scope.strippedFields) continue
+                    hideIf("${scope.key}.$field", check)
+                }
+            }
+
+            for (entry in EffectCatalog.ENTRIES) {
+                val check = { entry.title !in overrides }
+                for (field in ALL_LEAF_FIELDS) {
+                    if (field == "categoryFilter") continue
+                    hideIf("${entry.path}.$field", check)
                 }
             }
         }
@@ -204,15 +264,35 @@ class PotionEffectsHud : Hud(
     }
 
     private fun buildRows(): List<Row> {
-        val effects = currentEffects()
-        if (effects.isEmpty()) {
-            return if (!isReal || HudManager.isEditing) EXAMPLES.map { row(ResourceLocation.withDefaultNamespace(it.id), it.name, it.ticks, it.amplifier, false) }
+        if (!isReal) {
+            return exampleRows()
+        }
+
+        val active = mc.player?.activeEffects?.toList().orEmpty()
+        if (active.isEmpty()) {
+            return if (HudManager.isEditing) exampleRows()
             else emptyList()
         }
 
-        val ordered = sortEffects(effects, sorting, reversed)
-        return ordered.map { row(it) }
+        val editing = HudManager.isEditing
+        val visible = if (editing) active else active.filter(::shouldDisplayEffect)
+        if (visible.isEmpty()) return emptyList()
+
+        val ordered = sortEffects(visible, sorting, reversed)
+        return ordered.map { effect -> row(effect, dimmed = editing && !shouldDisplayEffect(effect)) }
     }
+
+    private fun exampleRows(): List<Row> =
+        EXAMPLES.map {
+            row(
+                ResourceLocation.withDefaultNamespace(it.id),
+                it.name,
+                it.ticks,
+                it.amplifier,
+                false,
+                categoryScopes.global
+            )
+        }
 
     private fun sortEffects(effects: List<MobEffectInstance>, sortingStack: Array<String>, reversed: Boolean): List<MobEffectInstance> {
         var sorted = effects
@@ -226,22 +306,46 @@ class PotionEffectsHud : Hud(
 
     private fun sortByRule(effects: List<MobEffectInstance>, rule: String): List<MobEffectInstance> {
         return when (rule) {
-            SORT_NAME -> effects.sortedBy { it.effect.value().displayName.string }
-            SORT_DURATION -> effects.sortedBy { if (it.isInfiniteDuration) Int.MAX_VALUE else it.duration }
-            SORT_AMPLIFIER -> effects.sortedByDescending { it.amplifier }
-            SORT_AMBIENT -> effects.sortedBy { it.isAmbient }
-            SORT_BAD_EFFECTS -> effects.sortedBy { it.effect.value().isBeneficial }
-            else -> effects
+            NAME -> effects.sortedBy { it.effect.value().displayName.string }
+            DURATION -> effects.sortedBy { if (it.isInfiniteDuration) Int.MAX_VALUE else it.duration }
+            AMPLIFIER -> effects.sortedByDescending { it.amplifier }
+            AMBIENT_EFFECTS -> effects.sortedBy { it.isAmbient }
+            BENEFICIAL_EFFECTS -> effects.sortedByDescending { it.effect.value().category == MobEffectCategory.BENEFICIAL }
+            NEUTRAL_EFFECTS -> effects.sortedByDescending { it.effect.value().category == MobEffectCategory.NEUTRAL }
+            HARMFUL_EFFECTS -> effects.sortedByDescending { it.effect.value().category == MobEffectCategory.HARMFUL }
+            else -> {
+                val path = EffectCatalog.titleToPath[rule] ?: return effects
+                effects.sortedByDescending { BuiltInRegistries.MOB_EFFECT.getKey(it.effect.value())?.path == path }
+            }
         }
     }
 
-    private fun currentEffects(): List<MobEffectInstance> {
-        if (!isReal) return emptyList()
-        val player = mc.player ?: return emptyList()
-        return player.activeEffects.filter { it.showIcon() && (showAmbient || !it.isAmbient) }
+    private fun shouldDisplayEffect(effect: MobEffectInstance): Boolean {
+        if (!effect.showIcon()) return false
+        val values = valuesFor(effect)
+
+        if (!values.showEffects) return false
+        if (!values.ambientFilter[0] && effect.isAmbient) return false
+        if (!values.ambientFilter[1] && !effect.isAmbient) return false
+
+        if (!values.permanentEffects[0] && effect.isInfiniteDuration) return false
+        if (!values.permanentEffects[1] && !effect.isInfiniteDuration) return false
+
+        val min = values.durationRange[0]
+        val max = values.durationRange[1]
+        if (min != 0f || max != 0f) {
+            if (!effect.isInfiniteDuration && effect.duration / 20f !in min..max) return false
+        }
+
+        val category = effect.effect.value().category
+        if (!values.categoryFilter[0] && category == MobEffectCategory.BENEFICIAL) return false
+        if (!values.categoryFilter[1] && category == MobEffectCategory.NEUTRAL) return false
+        if (!values.categoryFilter[2] && category == MobEffectCategory.HARMFUL) return false
+
+        return true
     }
 
-    private fun row(effect: MobEffectInstance): Row {
+    private fun row(effect: MobEffectInstance, dimmed: Boolean = false): Row {
         val mobEffect = effect.effect.value()
         return row(
             BuiltInRegistries.MOB_EFFECT.getKey(mobEffect),
@@ -249,28 +353,136 @@ class PotionEffectsHud : Hud(
             effect.duration,
             effect.amplifier,
             effect.isInfiniteDuration,
+            valuesFor(effect),
+            dimmed,
         )
     }
 
-    private fun row(id: ResourceLocation?, name: String, ticks: Int, amplifier: Int, infinite: Boolean): Row {
+    private fun row(id: ResourceLocation?, name: String, ticks: Int, amplifier: Int, infinite: Boolean, values: EffectComponentValues, dimmed: Boolean = false): Row {
         val level = amplifier + 1
+        val amplifierText = if (values.showAmplifier && level > 1) {
+            if (values.amplifierStyle == ROMAN) roman(level) else level.toString()
+        } else null
+
         val title = when {
-            !showName -> null
-            showAmplifier && level > 1 -> "$name ${if (amplifierStyle == ROMAN) roman(level) else level}"
-            else -> name
+            values.nameEnabled && amplifierText != null -> "$name $amplifierText"
+            values.nameEnabled -> name
+            amplifierText != null -> amplifierText
+            else -> null
         }
+
         val time = when {
-            !showDuration -> null
+            !values.durationEnabled -> null
             infinite -> INFINITE
             else -> formatDuration(ticks)
         }
-        return Row(if (showIcon && id != null) iconFor(id) else null, title, time, fade(ticks, infinite))
+        return Row(
+            icon = if (values.iconEnabled && id != null) iconFor(id) else null,
+            name = title,
+            duration = time,
+            fade = fade(ticks, infinite, values.blinkThreshold),
+            iconBlink = values.iconBlink,
+            nameBlink = values.nameBlink,
+            nameColor = values.nameColor,
+            durationBlink = values.durationBlink,
+            durationColor = values.durationColor,
+            dimmed = dimmed,
+        )
     }
 
-    private fun fade(ticks: Int, infinite: Boolean): Float {
+    private fun fade(ticks: Int, infinite: Boolean, blinkThreshold: Float): Float {
         if (infinite || blinkThreshold <= 0f || ticks > blinkThreshold * 20f) return 1f
         val phase = (System.currentTimeMillis() % BLINK_PERIOD).toFloat() / BLINK_PERIOD
         return BLINK_MIN_FADE + (1f - BLINK_MIN_FADE) * ((cos(phase * 2f * PI.toFloat()) + 1f) / 2f)
+    }
+
+    private fun textAlign(mode: Int): PolyAlign = when (mode) {
+        2 -> PolyAlign.Center
+        3 -> PolyAlign.Right
+        else -> PolyAlign.Left
+    }
+
+    private fun autoTextAlign(): PolyAlign {
+        if (textAlignment != 0) return textAlign(textAlignment)
+
+        if (selfAnchorPoint != HudAnchor.Auto) {
+            return horizontalFrom(selfAnchorPoint)
+        }
+
+        return when (section) {
+            Section.TopLeft, Section.CenterLeft, Section.BottomLeft -> PolyAlign.Left
+            Section.TopCenter, Section.Center, Section.BottomCenter -> PolyAlign.Center
+            Section.TopRight, Section.CenterRight, Section.BottomRight -> PolyAlign.Right
+        }
+    }
+
+    private fun horizontalFrom(anchor: HudAnchor): PolyAlign = when (anchor) {
+        HudAnchor.TopLeft, HudAnchor.Left, HudAnchor.BottomLeft -> PolyAlign.Left
+        HudAnchor.Top, HudAnchor.Center, HudAnchor.Bottom -> PolyAlign.Center
+        HudAnchor.TopRight, HudAnchor.Right, HudAnchor.BottomRight -> PolyAlign.Right
+        HudAnchor.Auto -> PolyAlign.Left
+    }
+
+    private fun direction(): Boolean {
+        if (listDirection != DIRECTION_AUTO) return listDirection == DIRECTION_HORIZONTAL
+
+        if (selfAnchorPoint != HudAnchor.Auto) {
+            return when (selfAnchorPoint) {
+                HudAnchor.Top, HudAnchor.Center, HudAnchor.Bottom -> true
+                else -> false
+            }
+        }
+
+        return when (section) {
+            Section.TopCenter, Section.Center, Section.BottomCenter -> true
+            else -> false
+        }
+    }
+
+    private fun layoutMode(): Int {
+        if (layoutMode != MODE_AUTO) return layoutMode
+
+        if (selfAnchorPoint != HudAnchor.Auto) {
+            return when (selfAnchorPoint) {
+                HudAnchor.Top, HudAnchor.Center, HudAnchor.Bottom -> MODE_STACKED
+                HudAnchor.Left, HudAnchor.Right -> MODE_FULL
+                HudAnchor.TopLeft, HudAnchor.TopRight, HudAnchor.BottomLeft, HudAnchor.BottomRight -> MODE_FULL
+                HudAnchor.Auto -> MODE_FULL
+            }
+        }
+
+        return when (section) {
+            Section.TopCenter, Section.Center, Section.BottomCenter -> MODE_STACKED
+            Section.CenterLeft, Section.CenterRight -> MODE_FULL
+            Section.TopLeft, Section.TopRight, Section.BottomLeft, Section.BottomRight -> MODE_FULL
+        }
+    }
+
+    private fun isBottomAligned(): Boolean {
+        if (selfAnchorPoint != HudAnchor.Auto) {
+            return when (selfAnchorPoint) {
+                HudAnchor.BottomLeft, HudAnchor.Bottom, HudAnchor.BottomRight -> true
+                else -> false
+            }
+        }
+        return when (section) {
+            Section.BottomLeft, Section.BottomCenter, Section.BottomRight -> true
+            else -> false
+        }
+    }
+
+    private fun styleFor(row: Row): RowStyle {
+        val dimAlpha = if (row.dimmed) EDITOR_DIM_ALPHA else 1f
+        val iconAlpha = (if (row.iconBlink) row.fade else 1f) * dimAlpha
+        val nameFade = (if (row.nameBlink) row.fade else 1f) * dimAlpha
+        val durationFade = (if (row.durationBlink) row.fade else 1f) * dimAlpha
+        return RowStyle(
+            iconAlpha = iconAlpha,
+            nameFade = nameFade,
+            durationFade = durationFade,
+            nameColor = PolyColor(faded(row.nameColor.argb, nameFade), row.nameColor.chroma, row.nameColor.chromaSpeed),
+            durationColor = PolyColor(faded(row.durationColor.argb, durationFade), row.durationColor.chroma, row.durationColor.chromaSpeed),
+        )
     }
 
     @Composable
@@ -279,50 +491,141 @@ class PotionEffectsHud : Hud(
         if (list.isEmpty()) return
         val scale = textScale.coerceAtLeast(0.01f)
 
+        val maxRowWidth = remember(list, scale, font, layoutMode()) {
+            val mode = layoutMode()
+            val hasAnyIcon = list.any { it.icon != null }
+            val iconWidth = ICON * scale
+            val iconGap = ICON_GAP * scale
+
+            list.maxOf { row ->
+                val nameWidth = row.name?.let { measureWidth?.invoke(it, scale) ?: 0f } ?: 0f
+                val durationWidth = row.duration?.let { measureWidth?.invoke(it, scale) ?: 0f } ?: 0f
+                when (mode) {
+                    MODE_STACKED -> maxOf(if (row.icon != null) iconWidth else 0f, nameWidth, durationWidth)
+                    MODE_SINGLE_LINE -> {
+                        val gapWidth = if (row.name != null && row.duration != null) charWidth(scale) else 0f
+                        val textWidth = nameWidth + gapWidth + durationWidth
+                        (if (hasAnyIcon) iconWidth + iconGap else 0f) + textWidth
+                    }
+                    else -> (if (hasAnyIcon) iconWidth + iconGap else 0f) + maxOf(nameWidth, durationWidth)
+                }
+            }
+        }
+
+        val horizontal = direction()
         val modifier = hudBackground().padding(padLeft, padTop, padRight, padBottom)
 
         PolyBox(modifier = modifier) {
-            PolyColumn(gap = spacing * scale) {
-                for (row in list) Effect(row, scale)
-            }
-        }
-    }
-
-    @Composable
-    private fun Effect(row: Row, scale: Float) {
-        PolyRow(gap = ICON_GAP * scale) {
-            if (row.icon != null) Icon(row.icon, ICON * scale, row.fade)
-            if (row.name != null || row.duration != null) {
-                PolyColumn(gap = LINE_GAP * scale, modifier = PolyModifier.align(PolyAlign.Center)) {
-                    if (row.name != null) Line(row.name, scale, row.fade)
-                    if (row.duration != null) Line(row.duration, scale, row.fade)
+            if (horizontal) {
+                PolyRow(gap = spacing * scale) {
+                    for (row in list) Effect(row, scale, maxRowWidth)
+                }
+            } else {
+                PolyColumn(gap = spacing * scale) {
+                    for (row in list) Effect(row, scale, maxRowWidth)
                 }
             }
         }
     }
 
     @Composable
-    private fun Icon(icon: Image, size: Float, fade: Float) {
-        PolyCanvas(PolyModifier.size(size, size)) { x, y, w, h ->
-            iconPaint.alpha = (255f * fade).toInt().coerceIn(0, 255)
+    private fun Effect(row: Row, scale: Float, maxRowWidth: Float) {
+        val mode = layoutMode()
+        if (mode == MODE_STACKED) {
+            StackedEffect(row, scale, maxRowWidth)
+            return
+        }
+
+        val style = styleFor(row)
+        val align = autoTextAlign()
+
+        val iconBlock: @Composable () -> Unit = {
+            if (row.icon != null) Icon(row.icon, ICON * scale, style.iconAlpha)
+        }
+
+        PolyBox(modifier = PolyModifier.width(maxRowWidth)) {
+            PolyRow(gap = ICON_GAP * scale, modifier = PolyModifier.align(align)) {
+                if (align != PolyAlign.Right) iconBlock()
+
+                if (row.name != null || row.duration != null) {
+                    if (mode == MODE_SINGLE_LINE) CompactText(row, scale, style, align)
+                    else FullText(row, scale, style, align)
+                }
+
+                if (align == PolyAlign.Right) iconBlock()
+            }
+        }
+    }
+
+    @Composable
+    private fun CompactText(row: Row, scale: Float, style: RowStyle, align: PolyAlign) {
+        PolyRow(gap = charWidth(scale), modifier = PolyModifier.align(PolyAlign.Center)) {
+            if (align == PolyAlign.Right) {
+                if (row.duration != null) Line(row.duration, scale, style.durationFade, style.durationColor)
+                if (row.name != null) Line(row.name, scale, style.nameFade, style.nameColor)
+            } else {
+                if (row.name != null) Line(row.name, scale, style.nameFade, style.nameColor)
+                if (row.duration != null) Line(row.duration, scale, style.durationFade, style.durationColor)
+            }
+        }
+    }
+
+    @Composable
+    private fun FullText(row: Row, scale: Float, style: RowStyle, align: PolyAlign) {
+        PolyColumn(gap = LINE_GAP * scale, modifier = PolyModifier.align(PolyAlign.Center)) {
+            if (row.name != null) Line(row.name, scale, style.nameFade, style.nameColor, modifier = PolyModifier.align(align))
+            if (row.duration != null) Line(row.duration, scale, style.durationFade, style.durationColor, modifier = PolyModifier.align(align))
+        }
+    }
+
+    @Composable
+    private fun StackedEffect(row: Row, scale: Float, maxWidth: Float) {
+        val style = styleFor(row)
+        val reversed = isBottomAligned()
+
+        val iconBlock: @Composable () -> Unit = {
+            if (row.icon != null) Icon(row.icon, ICON * scale, style.iconAlpha, modifier = PolyModifier.align(PolyAlign.Center))
+        }
+        val nameBlock: @Composable () -> Unit = {
+            if (row.name != null) Line(row.name, scale, style.nameFade, style.nameColor, modifier = PolyModifier.align(PolyAlign.Center))
+        }
+        val durationBlock: @Composable () -> Unit = {
+            if (row.duration != null) Line(row.duration, scale, style.durationFade, style.durationColor, modifier = PolyModifier.align(PolyAlign.Center))
+        }
+
+        PolyBox(modifier = PolyModifier.width(maxWidth)) {
+            PolyColumn(gap = LINE_GAP * scale, modifier = PolyModifier.align(PolyAlign.Center)) {
+                if (reversed) {
+                    durationBlock(); nameBlock(); iconBlock()
+                } else {
+                    iconBlock(); nameBlock(); durationBlock()
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun Icon(icon: Image, size: Float, alpha: Float, modifier: PolyModifier = PolyModifier) {
+        PolyCanvas(modifier.size(size, size)) { x, y, w, h ->
+            iconPaint.alpha = (255f * alpha).toInt().coerceIn(0, 255)
             image(icon, x, y, w, h, iconPaint)
         }
     }
 
     @Composable
-    private fun Line(text: String, scale: Float, fade: Float) {
-        val color = PolyColor(faded(textColor, fade), textChroma, textChromaSpeed)
+    private fun Line(text: String, scale: Float, fade: Float, color: PolyColor, modifier: PolyModifier = PolyModifier) {
         if (font == Font.Minecraft) {
-            PolyMcText(text, color = color, shadow = showShadow, scale = scale)
+            PolyMcText(text, color, shadow = showShadow, scale = scale, modifier = modifier)
         } else {
             PolyText(
                 text,
-                color = color,
+                color,
                 fontSize = FONT_SIZE * scale,
                 shadow = showShadow,
                 shadowColor = PolyColor(faded(shadowColor, fade), shadowChroma, shadowChromaSpeed),
                 shadowOffset = shadowOffsetX,
                 font = getPoppinsFontName(),
+                modifier = modifier,
             )
         }
     }
@@ -334,6 +637,129 @@ class PotionEffectsHud : Hud(
     }
 
     override fun clone(): Hud = (super.clone() as PotionEffectsHud).also {
+        it.sorting = sorting.copyOf()
+        it.overrides = overrides.copyOf()
+
+        it.categoryScopes = categoryScopes.deepCopy()
+        it.effectScopes = effectScopes.deepCopy()
+
         it.rows = mutableStateOf(emptyList())
+    }
+
+    private class PerCategoryEffectSettings {
+        val global = EffectComponentSettings()
+        val beneficial = EffectComponentSettings()
+        val neutral = EffectComponentSettings()
+        val harmful = EffectComponentSettings()
+        val ambient = EffectComponentSettings()
+
+        val scopeDefs: List<ScopeDef> get() = listOf(
+            ScopeDef("global", "Global", global, isOverride = false),
+            ScopeDef("beneficial", BENEFICIAL_EFFECTS, beneficial, strippedFields = setOf("categoryFilter")),
+            ScopeDef("neutral", NEUTRAL_EFFECTS, neutral, strippedFields = setOf("categoryFilter")),
+            ScopeDef("harmful", HARMFUL_EFFECTS, harmful, strippedFields = setOf("categoryFilter")),
+            ScopeDef("ambient", AMBIENT_EFFECTS, ambient, strippedFields = setOf("ambientFilter", "categoryFilter", "permanentEffects", "emittingParticleEffects")),
+        )
+
+        fun copyFrom(other: PerCategoryEffectSettings) {
+            global.copyFrom(other.global)
+            beneficial.copyFrom(other.beneficial)
+            neutral.copyFrom(other.neutral)
+            harmful.copyFrom(other.harmful)
+            ambient.copyFrom(other.ambient)
+        }
+
+        fun deepCopy(): PerCategoryEffectSettings = PerCategoryEffectSettings().also { it.copyFrom(this) }
+    }
+
+    override fun addToSerialized(tree: Tree) {
+        super.addToSerialized(tree)
+        val collector = OneConfigCollector()
+
+        val liveSortOptions = buildList {
+            addAll(listOf(NAME, DURATION, AMPLIFIER, AMBIENT_EFFECTS, BENEFICIAL_EFFECTS, NEUTRAL_EFFECTS, HARMFUL_EFFECTS))
+            addAll(EffectCatalog.ENTRIES.map { it.title })
+        }.toTypedArray()
+
+        val sortingProp = tree.getProp("sorting") ?: throw IllegalStateException("sorting property not found on tree")
+        sortingProp.addMetadata("options", liveSortOptions)
+
+        for (scope in categoryScopes.scopeDefs) {
+            val t = Tree.tree(scope.key)
+            t.addMetadata(mapOf(
+                "title" to scope.title, "description" to scope.description,
+                "category" to "General", "subcategory" to "Effects",
+                "collapsed" to (scope.key != "global")
+            ))
+            collector.handle(t, scope.settings, 0)
+            for (field in scope.strippedFields) stripProperty(t, field)
+            tree.put(t)
+        }
+
+        for (entryDef in EffectCatalog.ENTRIES) {
+            val settings = effectScopes.byPath.getValue(entryDef.path)
+            val t = Tree.tree(entryDef.path)
+            t.addMetadata(mapOf(
+                "title" to entryDef.title,
+                "description" to "Overrides for the ${entryDef.title} effect.",
+                "category" to "General", "subcategory" to "Effects",
+                "collapsed" to true
+            ))
+            collector.handle(t, settings, 0)
+            stripProperty(t, "categoryFilter")
+            tree.put(t)
+        }
+
+        val liveOptions = buildList {
+            addAll(categoryScopes.scopeDefs.filter { it.isOverride }.map { it.title })
+            addAll(EffectCatalog.ENTRIES.map { it.title })
+        }.toTypedArray()
+
+        val prop = tree.getProp("overrides") ?: throw IllegalStateException("overrides property not found on tree")
+        prop.addMetadata("options", liveOptions)
+    }
+
+    private fun valuesFor(effect: MobEffectInstance): EffectComponentValues {
+        val mobEffect = effect.effect.value()
+        val id = BuiltInRegistries.MOB_EFFECT.getKey(mobEffect)
+        val categoryScope = when (mobEffect.category) {
+            MobEffectCategory.BENEFICIAL -> categoryScopes.beneficial
+            MobEffectCategory.NEUTRAL -> categoryScopes.neutral
+            MobEffectCategory.HARMFUL -> categoryScopes.harmful
+        }
+
+        for (entry in overrides) {
+            val resolved = when (entry) {
+                BENEFICIAL_EFFECTS -> categoryScope.takeIf { mobEffect.category == MobEffectCategory.BENEFICIAL }
+                NEUTRAL_EFFECTS -> categoryScope.takeIf { mobEffect.category == MobEffectCategory.NEUTRAL }
+                HARMFUL_EFFECTS -> categoryScope.takeIf { mobEffect.category == MobEffectCategory.HARMFUL }
+                AMBIENT_EFFECTS -> categoryScopes.ambient.takeIf { effect.isAmbient }
+                else -> {
+                    val path = EffectCatalog.titleToPath[entry] ?: continue
+                    effectScopes.byPath[path]?.takeIf { id != null && id.path == path }
+                }
+            }
+            if (resolved != null) return resolved
+        }
+        return categoryScopes.global
+    }
+
+    private class PerEffectSettings {
+        val byPath: Map<String, EffectComponentSettings> =
+            EffectCatalog.ENTRIES.associate { it.path to EffectComponentSettings() }
+
+        fun deepCopy(): PerEffectSettings = PerEffectSettings().also { copy ->
+            for ((path, settings) in byPath) {
+                copy.byPath[path]?.copyFrom(settings)
+            }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun stripProperty(t: Tree, key: String) {
+        val theMapField = Tree::class.java.getDeclaredField("theMap")
+        theMapField.setAccessible()
+        val map = theMapField.get(t) as LinkedHashMap<String, Node>
+        map.remove(key)
     }
 }

--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/potion/ScopeDef.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/potion/ScopeDef.kt
@@ -1,0 +1,12 @@
+package org.polyfrost.evergreenhud.client.hud.potion
+
+class ScopeDef(
+    val key: String,
+    val title: String,
+    val settings: EffectComponentSettings,
+    val strippedFields: Set<String> = emptySet(),
+    val isOverride: Boolean = true,
+) {
+    val description: String
+        get() = if (isOverride) "Overrides for $key effects." else "Default settings, used when no override applies."
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Sorting now can be done on an individual effect basis alongside effect types
- Per-effect and effect type overrides have been added. This will be breaking for configs as global settings back been moved as well.
- Added effect filtering rules: Duration range, amplifier range, permanent effects/finite effects, effect categories, and all effects applicable
- Added text alignment, layout modes, and list direction options.
- Ambient toggle has been moved to a multi-select dropdown to also filter out nonambient effects
- Name and Duration colors have been split
- Blink/fading can now be individually toggled per component

I don't intend this to be merged as-is. There are some kinks that I feel like should be ironed out for before merging.

For example:
- I don't like how the sorting and overrides display all effect types and effects at once. I feel like a new option that lets you pick and choose similar to the ItemList would be better
- The Duration and Amplifier ranges I feel like shouldn't be a slider, and should have a near infinite-positive range. Currently limited for now. https://github.com/Polyfrost/OneConfig/issues/948
- Accordions don't support subcategory labels which I feel makes the interface a bit more cluttered
- Waiting for OneConfig 1.1.7 to be released on Maven to address a few issues

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Mainly just bringing feature parity as much as possible to https://github.com/Tellinq/Potion-Effects

## How to test
<!-- Provide steps to test this PR -->
Scenarios are going to expand over time as this is tested, so I will just list a few things that I would recommend:

1. Get in a scenario where amplifier effects are activated, either via a beacon, conduit, or the golden apple effects. Toggle the Ambient filters accordingly
2. Add permanent effects and toggle the permanent effects filter accordingly
3. Add several variety of effects and mess around with the duration and amplifier ranges as well as the override/sorting
4. Move the Potion Effects HUD around to test out the automatic layout. Also change manually in the HUD options.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Sorting now can be done on an individual effect basis alongside effect types
!Per-effect and effect type overrides have been added. This will be breaking for configs as global settings back been moved as well.
Added effect filtering rules: Duration range, amplifier range, permanent effects/finite effects, effect categories, and all effects applicable
Added text alignment, layout modes, and list direction options.
!Ambient toggle has been moved to a multi-select dropdown to also filter out nonambient effects
!Name and Duration colors have been split
Blink/fading can now be individually toggled per component
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->