### PR TITLE
fix(hud): render item cooldown overlays

### DIFF
--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/item/ItemIcon.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/item/ItemIcon.kt
@@ -16,8 +16,10 @@ import org.polyfrost.evergreenhud.client.hooks.HudOffscreen
 import org.polyfrost.oneconfig.api.hud.v1.Hud
 import org.polyfrost.oneconfig.internal.ui.components.item.ItemCatalog
 import org.polyfrost.oneconfig.internal.ui.components.item.itemImage
+import org.polyfrost.oneconfig.utils.v1.dsl.mc
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.ceil
 import kotlin.math.roundToInt
 
 const val ITEM_SIZE = 16f
@@ -27,6 +29,7 @@ private const val BAR_Y = 13f
 private const val BAR_WIDTH = 13f
 
 private val BAR_BACKGROUND = PolyColor(0xFF000000.toInt())
+private val COOLDOWN_OVERLAY = PolyColor(0x7FFFFFFF)
 
 private val itemPaint = Paint()
 
@@ -47,6 +50,8 @@ fun ItemIcon(
         if (!decorations) return@PolyBox
 
         if (stack.isDamageableItem && stack.damageValue > 0) DurabilityBar(stack, scale)
+        //? if >= 1.21.8
+        if (hud.isReal) CooldownOverlay(stack, scale)
 
         val count = countOverride ?: stack.count.takeIf { it > 1 }?.toString()
         if (count != null) {
@@ -56,6 +61,8 @@ fun ItemIcon(
                 modifier = PolyModifier.align(PolyAlign.BottomRight),
             )
         }
+        //? if < 1.21.8
+        //if (hud.isReal) CooldownOverlay(stack, scale)
     }
 }
 
@@ -93,6 +100,40 @@ inline fun <T> whenItemsReady(fallback: T, block: () -> T): T = try {
 }
 
 fun itemId(stack: ItemStack): String = BuiltInRegistries.ITEM.getKey(stack.item).toString()
+
+@Composable
+private fun CooldownOverlay(stack: ItemStack, scale: Float) {
+    PolyCanvas(PolyModifier.size(ITEM_SIZE * scale, ITEM_SIZE * scale)) { x, y, _, _ ->
+        val height = cooldownOverlayHeight(cooldownPercent(stack))
+        if (height <= 0) return@PolyCanvas
+
+        rect(
+            x,
+            y + (ITEM_SIZE - height) * scale,
+            ITEM_SIZE * scale,
+            height * scale,
+            COOLDOWN_OVERLAY,
+        )
+    }
+}
+
+private fun cooldownPercent(stack: ItemStack): Float {
+    val player = mc.player ?: return 0f
+    //? if < 1.21.4 {
+    /*return player.cooldowns.getCooldownPercent(
+        stack.item,
+        mc.timer.getGameTimeDeltaPartialTick(true),
+    )
+    *///? } else {
+    return player.cooldowns.getCooldownPercent(
+        stack,
+        mc.deltaTracker.getGameTimeDeltaPartialTick(true),
+    )
+    //? }
+}
+
+internal fun cooldownOverlayHeight(cooldown: Float): Int =
+    ceil(ITEM_SIZE * cooldown.coerceIn(0f, 1f)).toInt()
 
 @Composable
 private fun DurabilityBar(stack: ItemStack, scale: Float) {

--- a/src/test/kotlin/org/polyfrost/evergreenhud/test/ItemIconCooldownTest.kt
+++ b/src/test/kotlin/org/polyfrost/evergreenhud/test/ItemIconCooldownTest.kt
@@ -1,0 +1,24 @@
+package org.polyfrost.evergreenhud.test
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.polyfrost.evergreenhud.client.hud.item.cooldownOverlayHeight
+
+class ItemIconCooldownTest {
+
+    @Test
+    fun `cooldown overlay uses vanilla pixel rounding`() {
+        assertEquals(0, cooldownOverlayHeight(0f))
+        assertEquals(1, cooldownOverlayHeight(0.01f))
+        assertEquals(1, cooldownOverlayHeight(1f / 16f))
+        assertEquals(2, cooldownOverlayHeight(Math.nextUp(1f / 16f)))
+        assertEquals(8, cooldownOverlayHeight(0.5f))
+        assertEquals(16, cooldownOverlayHeight(1f))
+    }
+
+    @Test
+    fun `cooldown overlay clamps progress to the item bounds`() {
+        assertEquals(0, cooldownOverlayHeight(-1f))
+        assertEquals(16, cooldownOverlayHeight(2f))
+    }
+}


### PR DESCRIPTION
## Description

Item cooldowns didn't show in the Inventory HUD. this brings back the vanilla cooldown overlay.

## Related Issue(s)
none

## How to test

enable the Inventory HUD, throw an ender pearl, and check that the cooldown shows on the item.
tested on 1.21.11. tests pass on all versions

## Release Notes

```release-note
fixed item cooldowns not showing in the Inventory HUD
```

## Documentation

No documentation changes.