### PR TITLE
Add FPS quality range and above number visibility options

### DIFF
--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/FpsHud.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/FpsHud.kt
@@ -6,9 +6,13 @@ import org.polyfrost.evergreenhud.client.utils.GenericNumberHud
 import org.polyfrost.evergreenhud.client.utils.quality
 import org.polyfrost.evergreenhud.client.utils.qualityColor
 import org.polyfrost.evergreenhud.client.utils.replace
+import org.polyfrost.oneconfig.api.config.v1.annotations.Number
+import org.polyfrost.oneconfig.api.config.v1.annotations.RangeSlider
 import org.polyfrost.oneconfig.api.config.v1.annotations.Slider
 import org.polyfrost.oneconfig.api.config.v1.annotations.Switch
 import org.polyfrost.oneconfig.api.config.v1.annotations.Text
+import org.polyfrost.oneconfig.api.hud.v1.Hud
+import org.polyfrost.oneconfig.api.hud.v1.HudManager
 
 private const val WORST_RATIO = 0.5
 
@@ -25,6 +29,12 @@ class FpsHud : GenericNumberHud(
     @Switch(title = "Color By Value", description = "Colours the value green when FPS is near your usual, fading to red at half of it.", subcategory = "Colors")
     private var colorByValue = false
 
+    @RangeSlider(title = "Show HUD Within Quality Range", description = "Show the FPS HUD only in a specific quality range, in %. 0-100% always shows.", min = 0F, max = 100F, step = 1F, subcategory = "Visibility")
+    private var showRange = floatArrayOf(0f, 100f)
+
+    @Number(title = "Hide Above FPS Number", description = "Hide the FPS HUD when above a specific number. 0 will always show.", min = 0F, max = 100000F, subcategory = "Visibility")
+    private var hideAboveNumber = 0
+
     init {
         accuracy = 0
     }
@@ -36,11 +46,25 @@ class FpsHud : GenericNumberHud(
             updateWhenChanged("formatString")
             updateWhenChanged("colorByValue")
             updateWhenChanged("updateRate")
+            updateWhenChanged("showRange")
+            updateWhenChanged("hideAboveNumber")
         }
+    }
+
+    override fun clone(): Hud = (super.clone() as FpsHud).apply {
+        showRange = this@FpsHud.showRange.copyOf()
     }
 
     override fun getText(): String {
         val data = FrameTimeHelper.latest
+        val baseline = FrameTimeHelper.baselineFps
+
+        val editing = HudManager.isEditing
+        val hiddenByRange = !editing && baseline > 0.0 && qualityPercent(data.currentFps.toFloat(), baseline).let { it < showRange[0] || it > showRange[1] }
+        val hiddenByNumber = !editing && hideAboveNumber > 0 && data.currentFps > hideAboveNumber
+
+        autoHidden = hiddenByRange || hiddenByNumber
+
         return StringBuilder().append(formatString)
             .replace("#fps", format(data.currentFps))
             .replace("#avg", format(data.averageFps))
@@ -59,5 +83,10 @@ class FpsHud : GenericNumberHud(
         if (!colorByValue || baseline <= 0.0) return null
         val fps = FrameTimeHelper.latest.currentFps
         return qualityColor(quality(fps.toFloat(), (baseline * WORST_RATIO).toFloat(), baseline.toFloat()))
+    }
+
+    private fun qualityPercent(fps: Float, baseline: Double): Float {
+        val worst = (baseline * WORST_RATIO).toFloat()
+        return quality(fps, worst, baseline.toFloat()) * 100F
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Added the option to show the FPS HUD when the FPS quality is within a specific range
- Added the option to hide the FPS HUD if the value is currently above a specific threshold

Added these two as I am looking to find ways to only show specific HUD mods only when I *need* to see them. These criterias were ones that came to mind for the FPS HUD.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A - something I noticed that should be added

## How to test
<!-- Provide steps to test this PR -->
1. Adjust the options to how you would prefer
2. Observe the FPS HUD hiding once outside of the visibility criteria

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Added the option to show the FPS HUD when the FPS quality is within a specific range
Added the option to hide the FPS HUD if the value is currently above a specific threshold
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No