### PR TITLE
Combo HUD: Added Minimum Combo to show HUD

### DIFF
--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/ComboHud.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/ComboHud.kt
@@ -3,11 +3,13 @@ package org.polyfrost.evergreenhud.client.hud
 import org.polyfrost.evergreenhud.client.ServerDamageEntityEvent
 import org.polyfrost.evergreenhud.client.utils.CachedTextHud
 import org.polyfrost.evergreenhud.client.utils.uniqueEntityId
+import org.polyfrost.oneconfig.api.config.v1.annotations.Number
 import org.polyfrost.oneconfig.api.config.v1.annotations.Slider
+import org.polyfrost.oneconfig.api.config.v1.annotations.Switch
 import org.polyfrost.oneconfig.api.config.v1.annotations.Text
 import org.polyfrost.oneconfig.api.event.v1.eventHandler
 import org.polyfrost.oneconfig.api.event.v1.events.TickEvent
-import org.polyfrost.oneconfig.api.hud.v1.TextHud
+import org.polyfrost.oneconfig.api.hud.v1.HudManager
 import org.polyfrost.oneconfig.utils.v1.dsl.mc
 
 class ComboHud : CachedTextHud(
@@ -22,6 +24,9 @@ class ComboHud : CachedTextHud(
     @Text(title = "No Hit Message")
     var noHitMessage = "0"
 
+    @Number(title = "Minimum Combo to Show", description = "Only show the HUD once your combo reaches this many hits. 0 always shows.", min = 0F, max = 100F, subcategory = "Visibility")
+    var minCombo = 0F
+
     private var lastHitTime = 0L
     private var lastAttackId = -1
 
@@ -31,6 +36,7 @@ class ComboHud : CachedTextHud(
             field = value
             if (value == 0) updateWithText(noHitMessage)
             else updateWithText(value)
+            updateVisibility()
         }
 
     override fun setup() {
@@ -66,6 +72,13 @@ class ComboHud : CachedTextHud(
 
         if (isReal) {
             updateWhenChanged("noHitMessage")
+            updateWhenChanged("minCombo")
+        }
+    }
+
+    private fun updateVisibility() {
+        if (!HudManager.isEditing) {
+            autoHidden = minCombo > 0F && currentCombo < minCombo.toInt()
         }
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Added option to only show Combo HUD when a minimum combo amount has been reached

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
<!-- Provide steps to test this PR -->
1. Configure number to your preference
2. Make the Combo HUD display show a number above that threshold and observe the HUD automatically hiding/showing when the threshold is met/no longer met

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Added option to only show Combo HUD when a minimum combo amount has been reached
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No