### PR TITLE
Added Saturation visibility range

### DIFF
--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/SaturationHud.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/SaturationHud.kt
@@ -3,20 +3,40 @@ package org.polyfrost.evergreenhud.client.hud
 import org.polyfrost.evergreenhud.client.SaturationChangedEvent
 import org.polyfrost.evergreenhud.client.utils.GenericNumberHud
 import org.polyfrost.evergreenhud.client.utils.SaturationTracker
+import org.polyfrost.oneconfig.api.config.v1.annotations.RangeSlider
 import org.polyfrost.oneconfig.api.event.v1.eventHandler
+import org.polyfrost.oneconfig.api.hud.v1.Hud
+import org.polyfrost.oneconfig.api.hud.v1.HudManager
 
 class SaturationHud : GenericNumberHud(
     title = "Saturation",
     category = Category.INFO,
     defaultValue = 5f,
 ) {
+    @RangeSlider(title = "Show HUD Within Saturation Range", description = "Show the Saturation HUD only within a specific range. 0-20 always shows.", min = 0F, max = 20F, step = 1F, subcategory = "Visibility")
+    private var showRange = floatArrayOf(0f, 20f)
+
     override fun setup() {
         super.setup()
         if (isReal) {
             updateWithNumber(SaturationTracker.saturation)
+            updateWhenChanged("showRange")
         }
         eventHandler { (saturation): SaturationChangedEvent ->
             updateWithNumber(saturation)
         }
+    }
+
+    override fun clone(): Hud = (super.clone() as SaturationHud).apply {
+        showRange = this@SaturationHud.showRange.copyOf()
+    }
+
+    override fun getText(): String {
+        val value = SaturationTracker.saturation
+
+        val editing = HudManager.isEditing
+        autoHidden = !editing && (value < showRange[0] || value > showRange[1])
+
+        return format(value)
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Added a range slider to show the saturation HUD only in a specific range. Useful if users are only wanting to see saturation when it is low, which is generally when you need to see it.

## How to test
<!-- Provide steps to test this PR -->
1. Adjust the range slider to your preference
2. Observe HUD being visible/hidden when saturation is within or outside the given range

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Added an option to only show saturation within a given range
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No