### PR TITLE
Fix POLYPLUS3-CM

### DIFF
--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/EvergreenHudClient.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/EvergreenHudClient.kt
@@ -10,6 +10,7 @@ import net.minecraft.world.entity.Entity
 import org.polyfrost.evergreenhud.client.config.GlobalConfig
 import org.polyfrost.evergreenhud.client.hooks.EnderChestTracker
 import org.polyfrost.evergreenhud.client.hooks.HudOffscreen
+import org.polyfrost.evergreenhud.client.hooks.SkiaOffscreen
 import org.polyfrost.evergreenhud.client.hud.*
 import org.polyfrost.evergreenhud.client.hud.item.VanillaTextures
 import org.polyfrost.evergreenhud.client.hud.battery.BatteryHud
@@ -40,6 +41,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 object EvergreenHudClient : ClientModInitializer {
     override fun onInitializeClient() {
         FrameTimeHelper.initialize()
+        SkiaOffscreen.initialize()
         HudOffscreen.initialize()
         VanillaTextures.initialize()
         EnderChestTracker.initialize()

--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hooks/HudOffscreen.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hooks/HudOffscreen.kt
@@ -40,7 +40,7 @@ object HudOffscreen {
     private val LOGGER = LoggerFactory.getLogger("EvergreenHUD/Hud Offscreen")
 
     private val client: Minecraft get() = mc
-    private val blitPaint = Paint()
+    private val blitPaint by lazy { Paint() }
 
     private var target: TextureTarget? = null
     private var brt: BackendRenderTarget? = null
@@ -60,7 +60,7 @@ object HudOffscreen {
     private var loggedFirstFrame = false
     private var loggedNotReady = false
 
-    val isUsable: Boolean get() = !failed
+    val isUsable: Boolean get() = SkiaOffscreen.isAvailable && !failed
 
     fun initialize() {
         eventHandler { _: ResizeEvent -> invalidate() }
@@ -106,7 +106,7 @@ object HudOffscreen {
         val requests = if (pending.isEmpty()) emptyList() else ArrayList(pending)
         pending.clear()
         hasContent = false
-        if (requests.isEmpty() || failed) return
+        if (requests.isEmpty() || !isUsable) return
         if (!SkiaCtx.isReady) {
             if (!loggedNotReady) {
                 loggedNotReady = true

--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hooks/PlayerPreviewOffscreen.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hooks/PlayerPreviewOffscreen.kt
@@ -46,7 +46,7 @@ object PlayerPreviewOffscreen {
     private val LOGGER = LoggerFactory.getLogger("EvergreenHUD/Player Preview")
 
     private val client: Minecraft get() = mc
-    private val blitPaint = Paint()
+    private val blitPaint by lazy { Paint() }
 
     //? if >= 26.1 {
     private val projection by lazy { ProjectionMatrixBuffer("evergreenhud_player_preview") }
@@ -115,7 +115,7 @@ object PlayerPreviewOffscreen {
         val requests = if (pending.isEmpty()) emptyList() else pending.entries.map { it.key to it.value }
         pending.clear()
         for (slot in slots.values) slot.hasContent = false
-        if (failed || !SkiaCtx.isReady) return
+        if (failed || !SkiaOffscreen.isAvailable || !SkiaCtx.isReady) return
 
         val player = client.player ?: return
         val now = System.nanoTime()

--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hooks/SkiaOffscreen.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hooks/SkiaOffscreen.kt
@@ -3,13 +3,61 @@ package org.polyfrost.evergreenhud.client.hooks
 import com.mojang.blaze3d.pipeline.RenderTarget
 import org.jetbrains.skia.BackendRenderTarget
 import org.jetbrains.skia.ColorSpace
+import org.jetbrains.skia.Paint
 import org.jetbrains.skia.Surface
 import org.jetbrains.skia.SurfaceOrigin
+import org.jetbrains.skiko.Library
+import org.jetbrains.skiko.LibraryLoadException
+import org.jetbrains.skiko.SkikoProperties
+import org.jetbrains.skiko.hostId
+import org.jetbrains.skiko.hostOs
 import org.polyfrost.oneconfig.internal.ui.compose.SkiaCtx
 import org.polyfrost.oneconfig.internal.ui.services.VulkanService
+import org.slf4j.LoggerFactory
+import java.io.File
 
 object SkiaOffscreen {
+    private val LOGGER = LoggerFactory.getLogger("EvergreenHUD/Skia Offscreen")
+
     private var cached: VulkanService? = null
+
+    var isAvailable = false
+        private set
+
+    fun initialize() {
+        isAvailable = try {
+            Paint().close()
+            true
+        } catch (error: LinkageError) {
+            reportUnavailable(error)
+            false
+        } catch (error: LibraryLoadException) {
+            reportUnavailable(error)
+            false
+        }
+    }
+
+    private fun reportUnavailable(error: Throwable) {
+        val root = generateSequence(error) { it.cause }.last()
+        val path = runCatching { libraryPath() }.getOrElse { "an unresolved location" }
+        LOGGER.error(
+            "Skia native library could not be loaded from {}; offscreen HUD rendering is disabled: {}",
+            path,
+            root.toString(),
+            error,
+        )
+    }
+
+    private fun libraryPath(): String {
+        val name = "skiko-$hostId"
+        val fileName = System.mapLibraryName(name)
+        SkikoProperties.libraryPath?.let { return File(it, fileName).absolutePath }
+        val jvmLibrary = File(System.getProperty("java.home"), if (hostOs.isWindows) "bin" else "lib").resolve(fileName)
+        if (jvmLibrary.exists()) return jvmLibrary.absolutePath
+        val hash = Library::class.java.getResourceAsStream("/$fileName.sha256")?.use { it.bufferedReader().readLine() }
+        val directory = if (hash == null) File(SkikoProperties.dataPath) else File(SkikoProperties.dataPath, "$name-$hash")
+        return File(directory, fileName).absolutePath
+    }
 
     private fun service(): VulkanService? {
         cached?.let { return it }

--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/CustomImageHud.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/CustomImageHud.kt
@@ -70,8 +70,8 @@ class CustomImageHud : Hud(
     @Transient
     private var cachedStamp = 0L
 
-    @Transient
-    private val paint = Paint()
+    @delegate:Transient
+    private val paint by lazy { Paint() }
 
     init {
         showBackground = false

--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/PlayerHeadHud.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/PlayerHeadHud.kt
@@ -84,7 +84,7 @@ class PlayerHeadHud : Hud(
     }
 }
 
-private val HEAD_PAINT = Paint()
+private val HEAD_PAINT by lazy { Paint() }
 
 private object PlayerHeadTexture {
     private val FALLBACK_UUID = UUID(0L, 0L)

--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/ResourcePackHud.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/ResourcePackHud.kt
@@ -54,7 +54,7 @@ class ResourcePackHud : Hud(
 
         private val DEFAULT_ICON = ResourceLocation.withDefaultNamespace("textures/misc/unknown_pack.png")
 
-        private val iconPaint = Paint()
+        private val iconPaint by lazy { Paint() }
         private val iconCache = HashMap<String, Image>()
         private val texturedCache = HashMap<String, Boolean>()
         private var cachedIds: List<String>? = null

--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/item/ItemIcon.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/item/ItemIcon.kt
@@ -34,7 +34,7 @@ private const val BAR_WIDTH = 13f
 private val BAR_BACKGROUND = PolyColor(0xFF000000.toInt())
 private val COOLDOWN_OVERLAY = PolyColor(0x7FFFFFFF)
 
-private val itemPaint = Paint()
+private val itemPaint by lazy { Paint() }
 
 private val requestedIcons: MutableSet<String> = Collections.newSetFromMap(ConcurrentHashMap())
 

--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/item/VanillaTextures.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/item/VanillaTextures.kt
@@ -43,7 +43,7 @@ private const val CONTAINER_TEXTURE_SIZE = 256f
 private const val GENERIC_54_GUI_HEIGHT = 222f
 private const val SHULKER_BOX_GUI_HEIGHT = 166f
 
-private val paint = Paint()
+private val paint by lazy { Paint() }
 
 class VanillaTexture internal constructor(
     private val image: Image,

--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/keystrokes/KeystrokesHud.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/keystrokes/KeystrokesHud.kt
@@ -78,10 +78,12 @@ private const val DOWN = "▼"
 private const val LEFT = "◀"
 private const val RIGHT = "▶"
 
-private val KEY_PAINT = Paint().apply { isAntiAlias = true }
-private val LINE_PAINT = Paint().apply {
-    isAntiAlias = false
-    mode = PaintMode.STROKE
+private val KEY_PAINT by lazy { Paint().apply { isAntiAlias = true } }
+private val LINE_PAINT by lazy {
+    Paint().apply {
+        isAntiAlias = false
+        mode = PaintMode.STROKE
+    }
 }
 
 private fun snapToPixels(canvas: Canvas, x: Float, y: Float, w: Float, h: Float): Rect {

--- a/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/potion/PotionEffectsHud.kt
+++ b/src/main/kotlin/org/polyfrost/evergreenhud/client/hud/potion/PotionEffectsHud.kt
@@ -110,7 +110,7 @@ class PotionEffectsHud : Hud(
                 .map { it.name }
         }
 
-        private val iconPaint = Paint()
+        private val iconPaint by lazy { Paint() }
         private val iconCache = HashMap<ResourceLocation, Image?>()
         private var cachedPackIds: List<String>? = null
 


### PR DESCRIPTION
OneConfig's ComposeSupport gate only checks that the skiko classes resolve, without initializing them, so it never attempts the native load and still reports available on the users device